### PR TITLE
chore: add app usage manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # logos-storage-ui
 
+The Logos Storage UI is a file sharing application built on top of the [Logos Storage Module](https://github.com/logos-co/logos-storage-module) to showcase its capabilities.
+
 ## How to Build
 
 ### Using Nix
@@ -8,7 +10,7 @@
 
 ```bash
 # Build the app
-nix build 
+nix build
 
 # Or explicitly
 nix build '.#default'
@@ -80,6 +82,49 @@ After building the app with `nix build`, you can run it:
 ./result/bin/logos-storage-ui-app
 ```
 
+## Using The Application
+
+The first time the application starts, you will be greeted with an onboarding screen which will help you set up your node and establish
+connectivity. Check below to see which of the setup options best applies to your situation:
+
+**Case 1.** You are behind a NAT, but your node supports UPnP or NAT-PMP.
+
+In this case, you should use the `Guided` setup option followed by the `UPnP` option, and Logos storage will use that to configure
+the network automatically for you.
+
+**Case 2.** You are behind a NAT with no UPnP or NAT-PMP support, but you can set up port forwarding rules manually.
+
+In this case, you should use the `Guided` setup option followed by the `Port Forwarding` option. Logos storage requires one TCP and one UDP
+port. The onboarding UI will ask you for which TCP port to use, whereas the UDP port is fixed at 8090. You will need to forward both of
+them in your router. In case you cannot forward UDP/8090, see Case 3.
+
+**Case 3.** You need to manually configure the network settings or would like to modify other node configuration options.
+
+In this case, you should use the `Advanced` setup option. This will display a prepopulated configuration JSON which you can then manually edit to suit your needs. See the module's [API reference](https://logos-co.github.io/logos-storage-module/api_reference.html) for a list of configuration options.
+
+After selecting the appropriate option and clicking `Continue`, the connectivity checker will kick in. If the node is reachable, you should
+see a message saying "your node is up and reachable". If the node is not reachable, you will need to [troubleshoot](#troubleshooting) your connection.
+Alternatively, you can choose to continue anyway, but you will only be able to _download_ files from other nodes.
+
+### Sharing a File
+
+To share a file, locate the upload panel and click on it. This will open a file selector. Select the file you would like to share and click
+`Open`. This will upload the file into the node and begin sharing it with other nodes in the network. The Content Identifier (CID) for the
+file -- a string like `zDvZRwzm49ZJLzxheYtydzx6AcNVSrf69LriUWjPr1SNLVnaXfj2` -- will be displayed in the upload panel. You can share this
+string with other people to allow them to download the file.
+
+### Downloading a File
+
+To download a file, you must first paste the file's CID into the `Fetch manifest` panel and click `Fetch`. This will download the file's metadata from the network.
+Once the metadata is downloaded, you will see an entry appearing in the `Manifests` list at the bottom of the UI. To download the file, click on the download
+next to the entry and a file selector will open, allowing you to choose where to save the file. Once you select a location, the file will be downloaded.
+The download progress widget will show progress in real-time.
+
+### Deleting Files
+
+To stop sharing a file, you can click on the trash bin icon close to the manifest entry corresponding to the file you want to stop sharing. This will delete
+the file from the node and interrupt its sharing.
+
 ## Configuration
 
 After onboarding, settings are saved to a file whose location depends on the OS:
@@ -94,7 +139,7 @@ The settings are saved to the preferences file to preserve the onboarding defaul
 
 To restart the onboarding process, simply delete the prefences file and relaunch the application.
 
-The application also provides a JSON editor in the debug panel for runtime configuration tweaks. To apply changes, restart the Storage Module.
+The debug panel also provides access to the module's configuration JSON for runtime configuration tweaks. See the module's [API reference](https://logos-co.github.io/logos-storage-module/api_reference.html) for a list of configuration options. To apply changes, restart the Storage Module.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Adds an app usage manual, as requested in https://github.com/logos-co/journeys.logos.co/issues/9 and later stated on Discord:

> ok so for now, let's just target text where we have:
> 
> 1. explanation of what you can do with the app
> 2. flow of the most interesting action with no screenshot/videos, just button labels "click 'new group';" to start group chat, etc