### PR TITLE
chore: remove settings and log them instead

### DIFF
--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -448,30 +448,12 @@ void StorageBackend::logVersion() {
     debug("Logos Storage UI=1.0.0");
 }
 
-void StorageBackend::listSettings() {
-    qDebug() << "StorageBackend::listSettings called";
-
-    QSettings settings;
-
-    debug("Settings file: " + settings.fileName());
-
-    QStringList lines;
-    for (const QString &key : settings.allKeys()) {
-        if (key.startsWith("Storage")){
-          lines << key + " = " + settings.value(key).toString();
-        }
-    }
-    QString all = lines.join("\n");
-    debug("All settings:\n" + all);
-}
-
 void StorageBackend::restartOnboarding() {
     qDebug() << "StorageBackend::restartOnboarding called";
 
     QSettings settings;
     settings.setValue("Storage/onboardingCompleted", false);
     settings.sync();
-    StorageBackend::listSettings();
     emit onboardingRestarted();
 }
 

--- a/src/StorageBackend.h
+++ b/src/StorageBackend.h
@@ -77,7 +77,6 @@ class StorageBackend : public StorageBackendSimpleSource {
     // Other log methods for debug
     void logDataDir() override;
     void logVersion() override;
-    void listSettings() override;
     void restartOnboarding() override;
     void logSpr() override;
     void logPeerId() override;

--- a/src/StorageBackend.rep
+++ b/src/StorageBackend.rep
@@ -53,7 +53,6 @@ class StorageBackend
     SLOT(void logDebugInfo())
     SLOT(void logDataDir())
     SLOT(void logVersion())
-    SLOT(void listSettings())
     SLOT(void logSpr())
     SLOT(void logPeerId())
 

--- a/src/qml/DebugPanel.qml
+++ b/src/qml/DebugPanel.qml
@@ -20,12 +20,24 @@ ColumnLayout {
         property string downloadFolderPath: ""
     }
 
+    function settingsLocation() {
+        const org = Qt.application.organization
+        const app = Qt.application.name
+        const domain = Qt.application.domain
+        if (Qt.platform.os === "osx") {
+            const rev = domain ? domain.split(".").reverse().join(".") : org
+            return "~/Library/Preferences/" + rev + "." + app + ".plist"
+        }
+        if (Qt.platform.os === "windows")
+            return "HKEY_CURRENT_USER\\Software\\" + org + "\\" + app
+        const cfg = StandardPaths.writableLocation(StandardPaths.GenericConfigLocation)
+        return cfg + "/" + org + "/" + app + ".conf"
+    }
+
     onRunningChanged: {
         if (!root.running)
             return
-        const cfg = StandardPaths.writableLocation(StandardPaths.GenericConfigLocation)
-        console.log("[QML] settings file =",
-                    cfg + "/" + Qt.application.organization + "/" + Qt.application.name + ".conf")
+        console.log("[QML] settings file =", root.settingsLocation())
         console.log("[QML] Storage/onboardingCompleted =", storageSettings.onboardingCompleted)
         console.log("[QML] Storage/downloadFolderPath =", storageSettings.downloadFolderPath)
     }

--- a/src/qml/DebugPanel.qml
+++ b/src/qml/DebugPanel.qml
@@ -1,6 +1,5 @@
 import QtQuick
 import QtQuick.Layouts
-import QtCore
 import Logos.Theme
 import Logos.Controls
 
@@ -11,36 +10,6 @@ ColumnLayout {
     property var backend: MockBackend
     property bool isOpen: false
     property bool running: false
-
-    Settings {
-        id: storageSettings
-        category: "Storage"
-
-        property bool onboardingCompleted: false
-        property string downloadFolderPath: ""
-    }
-
-    function settingsLocation() {
-        const org = Qt.application.organization
-        const app = Qt.application.name
-        const domain = Qt.application.domain
-        if (Qt.platform.os === "osx") {
-            const rev = domain ? domain.split(".").reverse().join(".") : org
-            return "~/Library/Preferences/" + rev + "." + app + ".plist"
-        }
-        if (Qt.platform.os === "windows")
-            return "HKEY_CURRENT_USER\\Software\\" + org + "\\" + app
-        const cfg = StandardPaths.writableLocation(StandardPaths.GenericConfigLocation)
-        return cfg + "/" + org + "/" + app + ".conf"
-    }
-
-    onRunningChanged: {
-        if (!root.running)
-            return
-        console.log("[QML] settings file =", root.settingsLocation())
-        console.log("[QML] Storage/onboardingCompleted =", storageSettings.onboardingCompleted)
-        console.log("[QML] Storage/downloadFolderPath =", storageSettings.downloadFolderPath)
-    }
 
     anchors.fill: parent
     visible: root.isOpen

--- a/src/qml/DebugPanel.qml
+++ b/src/qml/DebugPanel.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import QtCore
 import Logos.Theme
 import Logos.Controls
 
@@ -10,6 +11,24 @@ ColumnLayout {
     property var backend: MockBackend
     property bool isOpen: false
     property bool running: false
+
+    Settings {
+        id: storageSettings
+        category: "Storage"
+
+        property bool onboardingCompleted: false
+        property string downloadFolderPath: ""
+    }
+
+    onRunningChanged: {
+        if (!root.running)
+            return
+        const cfg = StandardPaths.writableLocation(StandardPaths.GenericConfigLocation)
+        console.log("[QML] settings file =",
+                    cfg + "/" + Qt.application.organization + "/" + Qt.application.name + ".conf")
+        console.log("[QML] Storage/onboardingCompleted =", storageSettings.onboardingCompleted)
+        console.log("[QML] Storage/downloadFolderPath =", storageSettings.downloadFolderPath)
+    }
 
     anchors.fill: parent
     visible: root.isOpen
@@ -47,13 +66,6 @@ ColumnLayout {
                 implicitWidth: 80
                 enabled: root.running
                 onClicked: root.backend.logVersion()
-            }
-            LogosStorageButton {
-                text: "Settings"
-                implicitHeight: 32
-                implicitWidth: 90
-                enabled: root.running
-                onClicked: root.backend.listSettings()
             }
             LogosStorageButton {
                 text: "Restart onboarding"

--- a/src/qml/MockBackend.qml
+++ b/src/qml/MockBackend.qml
@@ -54,7 +54,6 @@ QtObject {
     function logDataDir() {}
     function logSpr() {}
     function logVersion() {}
-    function listSettings() {}
     function restartOnboarding() {}
     function saveUserConfig(json) {}
     function saveCurrentConfig() {}


### PR DESCRIPTION
This PR removes the Settings button which was displaying wrong settings file and instead logs the correct file in logs: 

```
qml: [QML] settings file = file:///home/arnaud/.config/Logos/LogosStandalone.conf
qml: [QML] Storage/onboardingCompleted = true
qml: [QML] Storage/downloadFolderPath = file:///home/arnaud
```