### PR TITLE
fix: avoid reentrant widget refresh calls

### DIFF
--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -78,6 +78,18 @@ void StorageBackend::debug(const QString& log, const QString& level) {
     }
 }
 
+void StorageBackend::logLifecyclePeers(const QString& phase) {
+    LogosResult result = m_logos->storage_module.debug();
+    if (!result.success) {
+        qDebug() << "StorageBackend lifecycle" << phase << "debug failed:" << result.getError();
+        return;
+    }
+
+    QVariantMap map = result.getMap();
+    QVariantList nodes = map.value("table").toMap().value("nodes").toList();
+    qDebug() << "StorageBackend lifecycle" << phase << "peer count:" << nodes.size();
+}
+
 void StorageBackend::enqueueStorageOp(std::function<void()> op) {
     m_storageOps.enqueue(std::move(op));
 
@@ -154,16 +166,26 @@ void StorageBackend::doInit(QString configJson) {
     qDebug() << "StorageBackend::initStorage: init";
 
     if (!result) {
+        m_contextInitialized = false;
         setStatus(Destroyed);
         reportError("Failed to init storage");
         emit initCompleted(false, "Failed to init storage");
         return;
     }
 
+    m_contextInitialized = true;
     setStatus(Stopped);
+
+    if (m_eventsSubscribed) {
+        debug("new config is: " + configJson);
+        emit initCompleted(true, QString());
+        return;
+    }
 
     if (!m_logos->storage_module.on("storageStart", [this](const QVariantList& data) {
             QJsonObject payload = QJsonDocument::fromJson(data[0].toString().toUtf8()).object();
+            qDebug() << "StorageBackend lifecycle storageStart payload:"
+                     << QString::fromUtf8(QJsonDocument(payload).toJson(QJsonDocument::Compact));
             bool success = payload["success"].toBool();
 
             if (!success) {
@@ -188,6 +210,8 @@ void StorageBackend::doInit(QString configJson) {
 
     if (!m_logos->storage_module.on("storageStop", [this](const QVariantList& data) {
             QJsonObject payload = QJsonDocument::fromJson(data[0].toString().toUtf8()).object();
+            qDebug() << "StorageBackend lifecycle storageStop payload:"
+                     << QString::fromUtf8(QJsonDocument(payload).toJson(QJsonDocument::Compact));
             bool success = payload["success"].toBool();
 
             if (!success) {
@@ -200,6 +224,21 @@ void StorageBackend::doInit(QString configJson) {
                 m_widgetRefreshQueued = false;
 
                 debug("Storage module stopped.");
+
+                enqueueStorageOp([this]() {
+                    qDebug() << "StorageBackend lifecycle destroying context after stop";
+                    LogosResult destroyResult = m_logos->storage_module.destroy();
+                    const QString destroyError = destroyResult.success ? QString() : destroyResult.getError();
+                    qDebug() << "StorageBackend lifecycle post-stop destroy result success:"
+                             << destroyResult.success << "error:" << destroyError;
+
+                    if (!destroyResult.success) {
+                        reportError("Error when trying to destroy stopped context: " + destroyError);
+                        return;
+                    }
+
+                    m_contextInitialized = false;
+                });
             }
 
             emit stopCompleted();
@@ -275,6 +314,7 @@ void StorageBackend::doInit(QString configJson) {
     }
 
     debug("new config is: " + configJson);
+    m_eventsSubscribed = true;
 
     emit initCompleted(true, QString());
 }
@@ -285,6 +325,7 @@ void StorageBackend::start() {
 
 void StorageBackend::doStart() {
     qDebug() << "StorageBackend: start method called";
+    qDebug() << "StorageBackend lifecycle start requested, current status:" << status();
 
     migrateUserConfigFile();
 
@@ -297,6 +338,17 @@ void StorageBackend::doStart() {
         debug("Cannot open the user config file.", "warning");
     }
 
+    if (status() == Stopped && !m_contextInitialized) {
+        if (m_config.isNull()) {
+            reportError("Failed to start storage: missing configuration.");
+            emit startFailed("Failed to start storage: missing configuration.");
+            return;
+        }
+
+        qDebug() << "StorageBackend lifecycle reinitializing context before start";
+        doInit(QString::fromUtf8(m_config.toJson(QJsonDocument::Compact)));
+    }
+
     if (status() != Stopped) {
         debug("The Storage Module is not initialised properly.");
         emit startFailed("The Storage Module is not initialised properly.");
@@ -305,8 +357,10 @@ void StorageBackend::doStart() {
 
     setStatus(Starting);
     debug("Starting Storage module...");
+    logLifecyclePeers("before start");
 
     auto result = m_logos->storage_module.start();
+    qDebug() << "StorageBackend lifecycle start command result:" << result;
 
     if (!result) {
         setStatus(Stopped);
@@ -324,6 +378,7 @@ void StorageBackend::stop() {
 
 void StorageBackend::doStop() {
     qDebug() << "StorageBackend: stop method called";
+    qDebug() << "StorageBackend lifecycle stop requested, current status:" << status();
 
     if (status() == Stopping) {
         debug("The Storage Module is already stopping.");
@@ -338,12 +393,16 @@ void StorageBackend::doStop() {
 
     setStatus(Stopping);
     debug("Stopping Storage module...");
+    logLifecyclePeers("before stop");
 
     auto result = m_logos->storage_module.stop();
+    const QString stopError = result.success ? QString() : result.getError();
+    qDebug() << "StorageBackend lifecycle stop command result success:" << result.success
+             << "error:" << stopError;
 
     if (!result.success) {
         setStatus(Running);
-        reportError("Error when trying to stop: " + result.getError());
+        reportError("Error when trying to stop: " + stopError);
         return;
     }
 
@@ -357,6 +416,11 @@ void StorageBackend::destroy() {
 void StorageBackend::doDestroy() {
     qDebug() << "StorageBackend: destroy method called";
 
+    if (!m_contextInitialized) {
+        qDebug() << "StorageBackend: Storage module context already destroyed.";
+        return;
+    }
+
     auto result = m_logos->storage_module.destroy();
 
     if (!result.success) {
@@ -364,6 +428,7 @@ void StorageBackend::doDestroy() {
         return;
     }
 
+    m_contextInitialized = false;
     qDebug() << "StorageBackend: Storage module destroyed.";
 }
 
@@ -701,13 +766,14 @@ void StorageBackend::doReloadIfChanged(QString configJsonStr) {
         return;
     }
 
-    if (status() == Stopped) {
+    if (status() == Stopped && m_contextInitialized) {
         LogosResult result = m_logos->storage_module.destroy();
 
         if (!result.success) {
             reportError("Failed to destroy the context error=" + result.getError());
             return;
         } else {
+            m_contextInitialized = false;
             setStatus(Destroyed);
         }
     }

--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -18,6 +18,9 @@
 #define STORAGE_UI_VERSION "unknown"
 #endif
 
+static constexpr int STORAGE_READINESS_RETRIES = 2;
+static constexpr int STORAGE_READINESS_RETRY_DELAY_MS = 500;
+
 // StorageBackend is responsible for managing the interaction with the storage module.
 // It is mocked in the QML.
 // There are currently 2 ways to display debug information:
@@ -105,9 +108,30 @@ void StorageBackend::requestWidgetRefresh() {
 
     m_widgetRefreshQueued = true;
     enqueueStorageOp([this]() { doRefreshSpace(); });
-    enqueueStorageOp([this]() {
-        doDownloadManifests();
-        m_widgetRefreshQueued = false;
+    enqueueWidgetManifestRefresh();
+}
+
+void StorageBackend::enqueueWidgetManifestRefresh(int attempt) {
+    enqueueStorageOp([this, attempt]() {
+        if (status() != Running) {
+            m_widgetRefreshQueued = false;
+            return;
+        }
+
+        const bool finalAttempt = attempt >= STORAGE_READINESS_RETRIES;
+        if (doDownloadManifests(finalAttempt)) {
+            m_widgetRefreshQueued = false;
+            return;
+        }
+
+        if (finalAttempt) {
+            m_widgetRefreshQueued = false;
+            return;
+        }
+
+        QTimer::singleShot(STORAGE_READINESS_RETRY_DELAY_MS, this, [this, attempt]() {
+            enqueueWidgetManifestRefresh(attempt + 1);
+        });
     });
 }
 
@@ -173,6 +197,7 @@ void StorageBackend::doInit(QString configJson) {
                 reportError("Failed to stop Storage module:" + message);
             } else {
                 setStatus(Stopped);
+                m_widgetRefreshQueued = false;
 
                 debug("Storage module stopped.");
             }
@@ -605,17 +630,25 @@ void StorageBackend::downloadManifests() {
     enqueueStorageOp([this]() { doDownloadManifests(); });
 }
 
-void StorageBackend::doDownloadManifests() {
+bool StorageBackend::doDownloadManifests(bool reportErrors) {
     qDebug() << "StorageBackend::downloadManifests called";
+
+    if (status() != Running) {
+        qDebug() << "StorageBackend::downloadManifests skipped because storage is not running";
+        return true;
+    }
 
     LogosResult result = m_logos->storage_module.manifests();
 
     if (!result.success) {
-        reportError("Failed to download manifests: " + result.getError());
-        return;
+        if (reportErrors) {
+            reportError("Failed to download manifests: " + result.getError());
+        }
+        return false;
     }
 
     emit manifestsUpdated(result.getList());
+    return true;
 }
 
 void StorageBackend::refreshSpace() {
@@ -624,6 +657,11 @@ void StorageBackend::refreshSpace() {
 
 void StorageBackend::doRefreshSpace() {
     qDebug() << "StorageBackend::refreshSpace called";
+
+    if (status() != Running) {
+        qDebug() << "StorageBackend::refreshSpace skipped because storage is not running";
+        return;
+    }
 
     LogosResult result = m_logos->storage_module.space();
 

--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -75,7 +75,47 @@ void StorageBackend::debug(const QString& log, const QString& level) {
     }
 }
 
+void StorageBackend::enqueueStorageOp(std::function<void()> op) {
+    m_storageOps.enqueue(std::move(op));
+
+    if (!m_storageOpRunning) {
+        QTimer::singleShot(0, this, &StorageBackend::runNextStorageOp);
+    }
+}
+
+void StorageBackend::runNextStorageOp() {
+    if (m_storageOpRunning || m_storageOps.isEmpty()) {
+        return;
+    }
+
+    m_storageOpRunning = true;
+    auto op = m_storageOps.dequeue();
+    op();
+    m_storageOpRunning = false;
+
+    if (!m_storageOps.isEmpty()) {
+        QTimer::singleShot(0, this, &StorageBackend::runNextStorageOp);
+    }
+}
+
+void StorageBackend::requestWidgetRefresh() {
+    if (m_widgetRefreshQueued) {
+        return;
+    }
+
+    m_widgetRefreshQueued = true;
+    enqueueStorageOp([this]() { doRefreshSpace(); });
+    enqueueStorageOp([this]() {
+        doDownloadManifests();
+        m_widgetRefreshQueued = false;
+    });
+}
+
 void StorageBackend::init(QString configJson) {
+    enqueueStorageOp([this, configJson]() { doInit(configJson); });
+}
+
+void StorageBackend::doInit(QString configJson) {
     qDebug() << "StorageBackend::initStorage called";
 
     m_config = QJsonDocument::fromJson(configJson.toUtf8());
@@ -114,7 +154,7 @@ void StorageBackend::init(QString configJson) {
 
                 debug("Storage module started.");
 
-                StorageBackend::fetchWidgetsData();
+                fetchWidgetsData();
 
                 emit startCompleted();
             }
@@ -167,7 +207,7 @@ void StorageBackend::init(QString configJson) {
             } else {
                 QString cid = payload["cid"].toString();
                 emit uploadCompleted(cid);
-                refreshWidgetsData();
+                requestWidgetRefresh();
             }
         })) {
         qWarning() << "StorageWidget: failed to subscribe to storageUploadDone events";
@@ -215,6 +255,10 @@ void StorageBackend::init(QString configJson) {
 }
 
 void StorageBackend::start() {
+    enqueueStorageOp([this]() { doStart(); });
+}
+
+void StorageBackend::doStart() {
     qDebug() << "StorageBackend: start method called";
 
     migrateUserConfigFile();
@@ -223,7 +267,7 @@ void StorageBackend::start() {
 
     if (file.exists() && file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         QString configJsonStr = QString::fromUtf8(file.readAll());
-        reloadIfChanged(configJsonStr);
+        doReloadIfChanged(configJsonStr);
     } else {
         debug("Cannot open the user config file.", "warning");
     }
@@ -250,6 +294,10 @@ void StorageBackend::start() {
 }
 
 void StorageBackend::stop() {
+    enqueueStorageOp([this]() { doStop(); });
+}
+
+void StorageBackend::doStop() {
     qDebug() << "StorageBackend: stop method called";
 
     if (status() == Stopping) {
@@ -278,6 +326,10 @@ void StorageBackend::stop() {
 }
 
 void StorageBackend::destroy() {
+    enqueueStorageOp([this]() { doDestroy(); });
+}
+
+void StorageBackend::doDestroy() {
     qDebug() << "StorageBackend: destroy method called";
 
     auto result = m_logos->storage_module.destroy();
@@ -291,6 +343,10 @@ void StorageBackend::destroy() {
 }
 
 void StorageBackend::logDebugInfo() {
+    enqueueStorageOp([this]() { doLogDebugInfo(); });
+}
+
+void StorageBackend::doLogDebugInfo() {
     auto result = m_logos->storage_module.debug();
 
     if (!result.success) {
@@ -306,6 +362,10 @@ void StorageBackend::logDebugInfo() {
 }
 
 void StorageBackend::uploadFile(QUrl url) {
+    enqueueStorageOp([this, url]() { doUploadFile(url); });
+}
+
+void StorageBackend::doUploadFile(QUrl url) {
     qDebug() << "StorageBackend: uploadFile called";
 
     if (!url.isLocalFile()) {
@@ -330,6 +390,10 @@ void StorageBackend::uploadFile(QUrl url) {
 }
 
 void StorageBackend::downloadFile(QString cid, QUrl url, qint64 totalBytes) {
+    enqueueStorageOp([this, cid, url, totalBytes]() { doDownloadFile(cid, url, totalBytes); });
+}
+
+void StorageBackend::doDownloadFile(QString cid, QUrl url, qint64 totalBytes) {
     qDebug() << "StorageBackend: downloadFile called";
 
     if (!url.isLocalFile()) {
@@ -356,6 +420,10 @@ void StorageBackend::downloadFile(QString cid, QUrl url, qint64 totalBytes) {
 }
 
 void StorageBackend::exists(QString cid) {
+    enqueueStorageOp([this, cid]() { doExists(cid); });
+}
+
+void StorageBackend::doExists(QString cid) {
     qDebug() << "StorageBackend::exists called";
 
     LogosResult result = m_logos->storage_module.exists(cid);
@@ -369,20 +437,29 @@ void StorageBackend::exists(QString cid) {
 }
 
 void StorageBackend::remove(QString cid) {
+    enqueueStorageOp([this, cid]() { doRemove(cid); });
+}
+
+void StorageBackend::doRemove(QString cid) {
     qDebug() << "StorageBackend::remove called with cid=" << cid;
 
     LogosResult result = m_logos->storage_module.remove(cid);
     if (!result.success) {
         reportError("Failed to remove " + cid + ": " + result.getError());
+        requestWidgetRefresh();
         return;
     }
 
     debug("Cid " + cid + " removed from local storage.");
 
-    refreshWidgetsData();
+    requestWidgetRefresh();
 }
 
 void StorageBackend::fetch(QString cid) {
+    enqueueStorageOp([this, cid]() { doFetch(cid); });
+}
+
+void StorageBackend::doFetch(QString cid) {
     qDebug() << "StorageBackend::fetch called";
 
     LogosResult result = m_logos->storage_module.fetch(cid);
@@ -396,6 +473,10 @@ void StorageBackend::fetch(QString cid) {
 }
 
 void StorageBackend::logVersion() {
+    enqueueStorageOp([this]() { doLogVersion(); });
+}
+
+void StorageBackend::doLogVersion() {
     qDebug() << "StorageBackend::version called";
 
     LogosResult result = m_logos->storage_module.version();
@@ -439,6 +520,10 @@ void StorageBackend::restartOnboarding() {
 }
 
 void StorageBackend::logPeerId() {
+    enqueueStorageOp([this]() { doLogPeerId(); });
+}
+
+void StorageBackend::doLogPeerId() {
     qDebug() << "StorageBackend::peerId called";
 
     LogosResult result = m_logos->storage_module.peerId();
@@ -452,6 +537,10 @@ void StorageBackend::logPeerId() {
 }
 
 void StorageBackend::logSpr() {
+    enqueueStorageOp([this]() { doLogSpr(); });
+}
+
+void StorageBackend::doLogSpr() {
     qDebug() << "StorageBackend::spr called";
 
     LogosResult result = m_logos->storage_module.spr();
@@ -465,6 +554,10 @@ void StorageBackend::logSpr() {
 }
 
 void StorageBackend::logDataDir() {
+    enqueueStorageOp([this]() { doLogDataDir(); });
+}
+
+void StorageBackend::doLogDataDir() {
     qDebug() << "StorageBackend::dataDir called";
 
     LogosResult result = m_logos->storage_module.dataDir();
@@ -478,6 +571,10 @@ void StorageBackend::logDataDir() {
 }
 
 void StorageBackend::downloadManifest(QString cid) {
+    enqueueStorageOp([this, cid]() { doDownloadManifest(cid); });
+}
+
+void StorageBackend::doDownloadManifest(QString cid) {
     qDebug() << "StorageBackend::downloadManifest called with cid=" << cid;
 
     LogosResult result = m_logos->storage_module.downloadManifest(cid);
@@ -501,10 +598,14 @@ void StorageBackend::downloadManifest(QString cid) {
     manifest["datasetSize"] = datasetSize;
     manifest["blockSize"]   = blockSize;
 
-    downloadManifests();
+    requestWidgetRefresh();
 }
 
 void StorageBackend::downloadManifests() {
+    enqueueStorageOp([this]() { doDownloadManifests(); });
+}
+
+void StorageBackend::doDownloadManifests() {
     qDebug() << "StorageBackend::downloadManifests called";
 
     LogosResult result = m_logos->storage_module.manifests();
@@ -518,6 +619,10 @@ void StorageBackend::downloadManifests() {
 }
 
 void StorageBackend::refreshSpace() {
+    enqueueStorageOp([this]() { doRefreshSpace(); });
+}
+
+void StorageBackend::doRefreshSpace() {
     qDebug() << "StorageBackend::refreshSpace called";
 
     LogosResult result = m_logos->storage_module.space();
@@ -535,6 +640,10 @@ void StorageBackend::refreshSpace() {
 }
 
 void StorageBackend::reloadIfChanged(QString configJsonStr) {
+    enqueueStorageOp([this, configJsonStr]() { doReloadIfChanged(configJsonStr); });
+}
+
+void StorageBackend::doReloadIfChanged(QString configJsonStr) {
     QJsonDocument config = QJsonDocument::fromJson(configJsonStr.toUtf8());
     if (config.isNull()) {
         debug("Invalid json detected !");
@@ -565,7 +674,7 @@ void StorageBackend::reloadIfChanged(QString configJsonStr) {
         }
     }
 
-    init(configJsonStr);
+    doInit(configJsonStr);
 
     m_config = config;
     saveUserConfig(configJsonStr);
@@ -716,6 +825,10 @@ void StorageBackend::enableNatExtConfig(int tcpPort) {
 }
 
 void StorageBackend::checkNodeIsUp() {
+    enqueueStorageOp([this]() { doCheckNodeIsUp(); });
+}
+
+void StorageBackend::doCheckNodeIsUp() {
     qDebug() << "StorageBackend::checkNodeIsUp called.";
 
     LogosResult result = m_logos->storage_module.debug();
@@ -767,60 +880,53 @@ void StorageBackend::checkNodeIsUp() {
         return;
     }
 
-    qDebug() << "Checking reachability for " << endpoints.size() << "endpoint(s)...";
+    QTimer::singleShot(0, this, [this, endpoints, nat]() {
+        qDebug() << "Checking reachability for " << endpoints.size() << "endpoint(s)...";
 
-    bool foundReachable = false;
-    for (const auto& [ip, port] : endpoints) {
-        QNetworkAccessManager manager;
-        const QUrl url(QString("%1/%2/%3").arg(PORT_CHECKER_PROVIDER).arg(ip).arg(port));
-        QNetworkReply* reply = manager.get(QNetworkRequest(url));
+        bool foundReachable = false;
+        for (const auto& [ip, port] : endpoints) {
+            QNetworkAccessManager manager;
+            const QUrl url(QString("%1/%2/%3").arg(PORT_CHECKER_PROVIDER).arg(ip).arg(port));
+            QNetworkReply* reply = manager.get(QNetworkRequest(url));
 
-        QEventLoop loop;
-        connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
-        loop.exec();
+            QEventLoop loop;
+            connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+            loop.exec();
 
-        if (reply->error() == QNetworkReply::NoError) {
-            const bool reachable = reply->readAll() == "True";
+            if (reply->error() == QNetworkReply::NoError) {
+                const bool reachable = reply->readAll() == "True";
 
-            QString statusStr = reachable ? "reachable" : "not reachable";
-            qDebug() << "StorageBackend::checkNodeIsUp " << ip << ":" << port << statusStr;
+                QString statusStr = reachable ? "reachable" : "not reachable";
+                qDebug() << "StorageBackend::checkNodeIsUp " << ip << ":" << port << statusStr;
 
-            if (reachable) {
-                foundReachable = true;
+                if (reachable) {
+                    foundReachable = true;
+                }
+            } else {
+                qDebug() << "StorageBackend::checkNodeIsUp Port check failed for" << ip << ":" << port
+                         << reply->errorString();
             }
-        } else {
-            qDebug() << "StorageBackend::checkNodeIsUp Port check failed for" << ip << ":" << port
-                     << reply->errorString();
+
+            reply->deleteLater();
         }
 
-        reply->deleteLater();
-    }
-
-    if (foundReachable) {
-        emit nodeIsUp();
-    } else {
-        if (nat == "upnp") {
-            emit nodeIsntUp("UPnP is configured but the node is not reachable from the internet. "
-                            "Try going back and configure port forwarding manually on your router.");
+        if (foundReachable) {
+            emit nodeIsUp();
         } else {
-            emit nodeIsntUp("No ports are reachable from the internet. "
-                            "Try going back and check your port forwarding configuration.");
+            if (nat == "upnp") {
+                emit nodeIsntUp("UPnP is configured but the node is not reachable from the internet. "
+                                "Try going back and configure port forwarding manually on your router.");
+            } else {
+                emit nodeIsntUp("No ports are reachable from the internet. "
+                                "Try going back and check your port forwarding configuration.");
+            }
         }
-    }
+    });
 }
 
 void StorageBackend::fetchWidgetsData() {
-    QMetaObject::invokeMethod(this, [this]() {
-        logDebugInfo();
-        refreshWidgetsData();
-    }, Qt::QueuedConnection);
-}
-
-void StorageBackend::refreshWidgetsData() {
-    QMetaObject::invokeMethod(this, [this]() {
-        refreshSpace();
-        QMetaObject::invokeMethod(this, &StorageBackend::downloadManifests, Qt::QueuedConnection);
-    }, Qt::QueuedConnection);
+    enqueueStorageOp([this]() { doLogDebugInfo(); });
+    requestWidgetRefresh();
 }
 
 void StorageBackend::loadUserConfig() {

--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -167,8 +167,7 @@ void StorageBackend::init(QString configJson) {
             } else {
                 QString cid = payload["cid"].toString();
                 emit uploadCompleted(cid);
-                QMetaObject::invokeMethod(this, &StorageBackend::refreshSpace, Qt::QueuedConnection);
-                QMetaObject::invokeMethod(this, &StorageBackend::downloadManifests, Qt::QueuedConnection);
+                refreshWidgetsData();
             }
         })) {
         qWarning() << "StorageWidget: failed to subscribe to storageUploadDone events";
@@ -380,9 +379,7 @@ void StorageBackend::remove(QString cid) {
 
     debug("Cid " + cid + " removed from local storage.");
 
-    QMetaObject::invokeMethod(this, &StorageBackend::refreshSpace,
-                              Qt::QueuedConnection);
-    QMetaObject::invokeMethod(this, &StorageBackend::downloadManifests, Qt::QueuedConnection);
+    refreshWidgetsData();
 }
 
 void StorageBackend::fetch(QString cid) {
@@ -813,9 +810,17 @@ void StorageBackend::checkNodeIsUp() {
 }
 
 void StorageBackend::fetchWidgetsData() {
-    QMetaObject::invokeMethod(this, &StorageBackend::logDebugInfo, Qt::QueuedConnection);
-    QMetaObject::invokeMethod(this, &StorageBackend::refreshSpace, Qt::QueuedConnection);
-    QMetaObject::invokeMethod(this, &StorageBackend::downloadManifests, Qt::QueuedConnection);
+    QMetaObject::invokeMethod(this, [this]() {
+        logDebugInfo();
+        refreshWidgetsData();
+    }, Qt::QueuedConnection);
+}
+
+void StorageBackend::refreshWidgetsData() {
+    QMetaObject::invokeMethod(this, [this]() {
+        refreshSpace();
+        QMetaObject::invokeMethod(this, &StorageBackend::downloadManifests, Qt::QueuedConnection);
+    }, Qt::QueuedConnection);
 }
 
 void StorageBackend::loadUserConfig() {

--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -92,6 +92,7 @@ void StorageBackend::logLifecyclePeers(const QString& phase) {
 
 void StorageBackend::enqueueStorageOp(std::function<void()> op) {
     m_storageOps.enqueue(std::move(op));
+    updateBusy();
 
     if (!m_storageOpRunning) {
         QTimer::singleShot(0, this, &StorageBackend::runNextStorageOp);
@@ -100,17 +101,24 @@ void StorageBackend::enqueueStorageOp(std::function<void()> op) {
 
 void StorageBackend::runNextStorageOp() {
     if (m_storageOpRunning || m_storageOps.isEmpty()) {
+        updateBusy();
         return;
     }
 
     m_storageOpRunning = true;
+    updateBusy();
     auto op = m_storageOps.dequeue();
     op();
     m_storageOpRunning = false;
+    updateBusy();
 
     if (!m_storageOps.isEmpty()) {
         QTimer::singleShot(0, this, &StorageBackend::runNextStorageOp);
     }
+}
+
+void StorageBackend::updateBusy() {
+    setBusy(m_storageOpRunning || !m_storageOps.isEmpty());
 }
 
 void StorageBackend::requestWidgetRefresh() {

--- a/src/StorageBackend.h
+++ b/src/StorageBackend.h
@@ -6,9 +6,11 @@
 #include <QFile>
 #include <QJsonArray>
 #include <QObject>
+#include <QQueue>
 #include <QString>
 #include <QStringList>
 #include <QTimer>
+#include <functional>
 
 static const int RET_OK = 0;
 static const int RET_PROGRESS = 3;
@@ -193,11 +195,37 @@ class StorageBackend : public StorageBackendSimpleSource {
     // Emit error(message)
     void reportError(const QString& message);
 
-    void refreshWidgetsData();
+    void enqueueStorageOp(std::function<void()> op);
+    void runNextStorageOp();
+    void requestWidgetRefresh();
+
+    void doInit(QString configJson);
+    void doStart();
+    void doDestroy();
+    void doStop();
+    void doLogDebugInfo();
+    void doLogDataDir();
+    void doLogVersion();
+    void doLogSpr();
+    void doLogPeerId();
+    void doExists(QString cid);
+    void doRemove(QString cid);
+    void doFetch(QString cid);
+    void doUploadFile(QUrl url);
+    void doDownloadFile(QString cid, QUrl url, qint64 totalBytes);
+    void doDownloadManifest(QString cid);
+    void doDownloadManifests();
+    void doRefreshSpace();
+    void doReloadIfChanged(QString configJson);
+    void doCheckNodeIsUp();
 
     // Logos related variables
     LogosAPI* m_logosAPI;
     LogosModules* m_logos;
+
+    QQueue<std::function<void()>> m_storageOps;
+    bool m_storageOpRunning = false;
+    bool m_widgetRefreshQueued = false;
 
     // Internal configuration object. It can be updated by
     // upnp or port forwarning methods.

--- a/src/StorageBackend.h
+++ b/src/StorageBackend.h
@@ -194,6 +194,7 @@ class StorageBackend : public StorageBackendSimpleSource {
     // Display log and add it to debugLogs
     // Emit error(message)
     void reportError(const QString& message);
+    void logLifecyclePeers(const QString& phase);
 
     void enqueueStorageOp(std::function<void()> op);
     void runNextStorageOp();
@@ -227,6 +228,8 @@ class StorageBackend : public StorageBackendSimpleSource {
     QQueue<std::function<void()>> m_storageOps;
     bool m_storageOpRunning = false;
     bool m_widgetRefreshQueued = false;
+    bool m_contextInitialized = false;
+    bool m_eventsSubscribed = false;
 
     // Internal configuration object. It can be updated by
     // upnp or port forwarning methods.

--- a/src/StorageBackend.h
+++ b/src/StorageBackend.h
@@ -198,6 +198,7 @@ class StorageBackend : public StorageBackendSimpleSource {
     void enqueueStorageOp(std::function<void()> op);
     void runNextStorageOp();
     void requestWidgetRefresh();
+    void enqueueWidgetManifestRefresh(int attempt = 0);
 
     void doInit(QString configJson);
     void doStart();
@@ -214,7 +215,7 @@ class StorageBackend : public StorageBackendSimpleSource {
     void doUploadFile(QUrl url);
     void doDownloadFile(QString cid, QUrl url, qint64 totalBytes);
     void doDownloadManifest(QString cid);
-    void doDownloadManifests();
+    bool doDownloadManifests(bool reportErrors = true);
     void doRefreshSpace();
     void doReloadIfChanged(QString configJson);
     void doCheckNodeIsUp();

--- a/src/StorageBackend.h
+++ b/src/StorageBackend.h
@@ -198,6 +198,7 @@ class StorageBackend : public StorageBackendSimpleSource {
 
     void enqueueStorageOp(std::function<void()> op);
     void runNextStorageOp();
+    void updateBusy();
     void requestWidgetRefresh();
     void enqueueWidgetManifestRefresh(int attempt = 0);
 

--- a/src/StorageBackend.h
+++ b/src/StorageBackend.h
@@ -193,6 +193,8 @@ class StorageBackend : public StorageBackendSimpleSource {
     // Emit error(message)
     void reportError(const QString& message);
 
+    void refreshWidgetsData();
+
     // Logos related variables
     LogosAPI* m_logosAPI;
     LogosModules* m_logos;

--- a/src/StorageBackend.rep
+++ b/src/StorageBackend.rep
@@ -13,6 +13,7 @@ class StorageBackend
 
     PROP(QString debugLogs READONLY)
     PROP(StorageStatus status READONLY)
+    PROP(bool busy READONLY)
     PROP(int defaultListenPort READONLY)
     PROP(QString defaultConfigJson READONLY)
 

--- a/src/qml/AdvancedSetup.qml
+++ b/src/qml/AdvancedSetup.qml
@@ -8,6 +8,7 @@ OnBoardingLayout {
     id: root
 
     property var backend: MockBackend
+    readonly property bool busy: root.backend && root.backend.busy
 
     signal back
     signal completed
@@ -45,6 +46,7 @@ OnBoardingLayout {
 
             LogosStorageButton {
                 text: "Back"
+                enabled: !root.busy
                 onClicked: root.back()
                 iconSource: "assets/arrow-left.png"
                 iconPosition: "left"
@@ -57,7 +59,7 @@ OnBoardingLayout {
             LogosStorageButton {
                 text: "Validate"
                 variant: "primary"
-                enabled: jsonEditor.isValid
+                enabled: jsonEditor.isValid && !root.busy
                 iconSource: "assets/arrow-right.png"
                 iconPosition: "right"
                 onClicked: {

--- a/src/qml/DebugPanel.qml
+++ b/src/qml/DebugPanel.qml
@@ -10,6 +10,7 @@ ColumnLayout {
     property var backend: MockBackend
     property bool isOpen: false
     property bool running: false
+    property bool busy: false
 
     anchors.fill: parent
     visible: root.isOpen
@@ -31,35 +32,35 @@ ColumnLayout {
                 text: "Debug"
                 implicitHeight: 32
                 implicitWidth: 70
-                enabled: root.running
+                enabled: root.running && !root.busy
                 onClicked: root.backend.logDebugInfo()
             }
             LogosStorageButton {
                 text: "Data dir"
                 implicitHeight: 32
                 implicitWidth: 80
-                enabled: root.running
+                enabled: root.running && !root.busy
                 onClicked: root.backend.logDataDir()
             }
             LogosStorageButton {
                 text: "Version"
                 implicitHeight: 32
                 implicitWidth: 80
-                enabled: root.running
+                enabled: root.running && !root.busy
                 onClicked: root.backend.logVersion()
             }
             LogosStorageButton {
                 text: "Settings"
                 implicitHeight: 32
                 implicitWidth: 90
-                enabled: root.running
+                enabled: root.running && !root.busy
                 onClicked: root.backend.listSettings()
             }
             LogosStorageButton {
                 text: "Restart onboarding"
                 implicitHeight: 32
                 implicitWidth: 150
-                enabled: root.running
+                enabled: root.running && !root.busy
                 onClicked: root.backend.restartOnboarding()
             }
 

--- a/src/qml/DownloadFolder.qml
+++ b/src/qml/DownloadFolder.qml
@@ -10,6 +10,7 @@ OnBoardingLayout {
     id: root
 
     property var backend: MockBackend
+    readonly property bool busy: root.backend && root.backend.busy
     property url downloadFolder: {
         const p = StandardPaths.standardLocations(
                     StandardPaths.HomeLocation)[0].toString()
@@ -114,6 +115,7 @@ OnBoardingLayout {
 
                     MouseArea {
                         anchors.fill: parent
+                        enabled: !root.busy
                         cursorShape: Qt.PointingHandCursor
                         onClicked: uploadDialog.open()
                     }
@@ -127,6 +129,7 @@ OnBoardingLayout {
 
             LogosStorageButton {
                 text: "Back"
+                enabled: !root.busy
                 onClicked: root.back()
                 iconSource: "assets/arrow-left.png"
                 iconPosition: "left"
@@ -142,6 +145,7 @@ OnBoardingLayout {
                 iconSource: "assets/arrow-right.png"
                 iconPosition: "right"
                 variant: "primary"
+                enabled: !root.busy
                 onClicked: {
                     settings.downloadFolderPath = root.downloadFolder.toString()
                     root.next()

--- a/src/qml/ManifestTable.qml
+++ b/src/qml/ManifestTable.qml
@@ -15,6 +15,7 @@ Card {
     property var manifests: []
     property bool panelOpen: false
     property bool isDownloading: false
+    property bool busy: false
     property string downloadFolderPath: ""
 
     // property var manifests: [{
@@ -298,7 +299,7 @@ Card {
                                         border.color: dlHover.hovered
                                                       && root.running && !root.isDownloading ? Theme.palette.primary : Theme.palette.borderInteractive
                                         border.width: 1
-                                        opacity: root.running && !root.isDownloading ? 1.0 : 0.35
+                                        opacity: root.running && !root.isDownloading && !root.busy ? 1.0 : 0.35
 
                                         Behavior on opacity {
                                             NumberAnimation {
@@ -321,7 +322,7 @@ Card {
                                         MouseArea {
                                             objectName: "downloadButton"
                                             anchors.fill: parent
-                                            enabled: root.running && !root.isDownloading
+                                            enabled: root.running && !root.isDownloading && !root.busy
                                             cursorShape: Qt.PointingHandCursor
                                             onClicked: {
                                                 const dest = root.downloadFolderPath.replace(/\/$/, "") + "/" + (modelData.filename || modelData.cid || "download")
@@ -341,9 +342,9 @@ Card {
                                         radius: Theme.spacing.radiusXlarge * 2
                                         color: Theme.palette.backgroundButton
                                         border.color: rmHover.hovered
-                                                      && root.running ? Theme.palette.primary : Theme.palette.borderInteractive
+                                                      && root.running && !root.busy && !root.isDownloading ? Theme.palette.primary : Theme.palette.borderInteractive
                                         border.width: 1
-                                        opacity: root.running ? 1.0 : 0.35
+                                        opacity: root.running && !root.busy && !root.isDownloading ? 1.0 : 0.35
 
                                         Behavior on opacity {
                                             NumberAnimation {
@@ -366,7 +367,7 @@ Card {
                                         MouseArea {
                                             objectName: "deleteButton"
                                             anchors.fill: parent
-                                            enabled: root.running
+                                            enabled: root.running && !root.busy && !root.isDownloading
                                             cursorShape: Qt.PointingHandCursor
                                             onClicked: {
                                                 if (modelData.cid.length > 0) {
@@ -415,6 +416,7 @@ Card {
             DebugPanel {
                 backend: root.backend
                 running: root.running
+                busy: root.busy
                 isOpen: panelOpen
             }
         }

--- a/src/qml/ManifestWidget.qml
+++ b/src/qml/ManifestWidget.qml
@@ -11,6 +11,7 @@ Card {
 
     property var backend: MockBackend
     property bool running: false
+    property bool busy: false
     property bool enabled: true
 
     RowLayout {
@@ -20,7 +21,7 @@ Card {
         anchors.bottom: bottomTitle.top
         anchors.bottomMargin: Theme.spacing.small
         spacing: Theme.spacing.medium
-        opacity: root.running ? 1.0 : 0.4
+        opacity: root.running && !root.busy ? 1.0 : 0.4
 
         Behavior on opacity {
             NumberAnimation {
@@ -34,7 +35,7 @@ Card {
             Layout.alignment: Qt.AlignTop
             placeholderText: "CID"
             isValid: true
-            enabled: root.running
+            enabled: root.running && !root.busy
         }
 
         LogosStorageButton {
@@ -43,7 +44,7 @@ Card {
             implicitHeight: 42
             variant: "secondary"
             Layout.alignment: Qt.AlignTop
-            enabled: cidInput.text.length > 0 && root.running && root.enabled
+            enabled: cidInput.text.length > 0 && root.running && root.enabled && !root.busy
             onClicked: {
                 root.enabled = false
                 root.backend.downloadManifest(cidInput.text)

--- a/src/qml/MockBackend.qml
+++ b/src/qml/MockBackend.qml
@@ -5,6 +5,7 @@ import QtQuick
 QtObject {
     readonly property bool isMock: true
     property int status: 0
+    property bool busy: false
     property string debugLogs: "Hello!"
     property int defaultListenPort: 8500
 

--- a/src/qml/NodeWidget.qml
+++ b/src/qml/NodeWidget.qml
@@ -165,7 +165,8 @@ Card {
                 variant: "secondary"
                 implicitHeight: 32
                 implicitWidth: 65
-                enabled: root.backend
+                enabled: root.backend && (root.effectiveStatus === StorageBackend.Running
+                                          || root.effectiveStatus === StorageBackend.Stopped)
                 onClicked: {
                     if (!root.backend)
                         return

--- a/src/qml/NodeWidget.qml
+++ b/src/qml/NodeWidget.qml
@@ -14,6 +14,7 @@ Card {
     property var backend: MockBackend
     property bool nodeIsUp: false
     property bool blinkOn: false
+    readonly property bool busy: root.backend && root.backend.busy
     readonly property int effectiveStatus: root.backend ? root.backend.status : StorageBackend.Destroyed
 
     property string downloadFolderPath: ""
@@ -77,6 +78,7 @@ Card {
 
                             MouseArea {
                                 anchors.fill: parent
+                                enabled: !root.busy
                                 cursorShape: Qt.PointingHandCursor
                                 onClicked: settingsPopup.open()
                             }
@@ -165,8 +167,9 @@ Card {
                 variant: "secondary"
                 implicitHeight: 32
                 implicitWidth: 65
-                enabled: root.backend && (root.effectiveStatus === StorageBackend.Running
-                                          || root.effectiveStatus === StorageBackend.Stopped)
+                enabled: root.backend && !root.busy
+                         && (root.effectiveStatus === StorageBackend.Running
+                             || root.effectiveStatus === StorageBackend.Stopped)
                 onClicked: {
                     if (!root.backend)
                         return
@@ -179,6 +182,7 @@ Card {
         SettingsPopup {
             id: settingsPopup
             backend: root.backend
+            busy: root.busy
             downloadFolderPath: root.downloadFolderPath
             onFolderPathChanged: function(path) { root.folderPathChanged(path) }
         }

--- a/src/qml/OnBoarding.qml
+++ b/src/qml/OnBoarding.qml
@@ -7,6 +7,7 @@ OnBoardingLayout {
     id: root
 
     property var backend: MockBackend
+    readonly property bool busy: root.backend && root.backend.busy
 
     signal back
     signal completed(bool upnpEnabled)
@@ -92,6 +93,7 @@ OnBoardingLayout {
                 text: "Back"
                 iconSource: "assets/arrow-left.png"
                 iconPosition: "left"
+                enabled: !root.busy
                 onClicked: root.back()
             }
 
@@ -104,7 +106,7 @@ OnBoardingLayout {
                 variant: "primary"
                 iconSource: "assets/arrow-right.png"
                 iconPosition: "right"
-                enabled: root.selectedMode !== -1
+                enabled: root.selectedMode !== -1 && !root.busy
                 onClicked: {
                     if (root.selectedMode === 0) {
                         root.backend.enableUpnpConfig()

--- a/src/qml/PortForwarding.qml
+++ b/src/qml/PortForwarding.qml
@@ -9,6 +9,7 @@ OnBoardingLayout {
     property var backend: MockBackend
     property var tcpPort: backend.defaultListenPort
     property bool loading: false
+    readonly property bool busy: root.backend && root.backend.busy
 
     signal back
     signal completed(int port)
@@ -101,7 +102,7 @@ OnBoardingLayout {
                     id: tcpPortTextField
                     placeholderText: "Enter the TCP port"
                     text: root.tcpPort
-                    enabled: !root.loading
+                    enabled: !root.loading && !root.busy
                     isValid: {
                         const val = parseInt(text)
                         return !isNaN(val) && val >= 0 && val <= 65535
@@ -122,7 +123,7 @@ OnBoardingLayout {
 
             LogosStorageButton {
                 text: "Back"
-                enabled: !root.loading
+                enabled: !root.loading && !root.busy
                 onClicked: root.back()
                 iconSource: "assets/arrow-left.png"
                 iconPosition: "left"
@@ -134,7 +135,7 @@ OnBoardingLayout {
 
             LogosStorageButton {
                 text: "Continue"
-                enabled: !root.loading && tcpPortTextField.isValid
+                enabled: !root.loading && !root.busy && tcpPortTextField.isValid
                 iconSource: "assets/arrow-right.png"
                 iconPosition: "right"
                 variant: "primary"

--- a/src/qml/SettingsPopup.qml
+++ b/src/qml/SettingsPopup.qml
@@ -11,6 +11,7 @@ Popup {
 
     property var backend: MockBackend
     property string downloadFolderPath: ""
+    property bool busy: false
 
     signal folderPathChanged(string path)
 
@@ -99,6 +100,7 @@ Popup {
 
                 MouseArea {
                     anchors.fill: parent
+                    enabled: !root.busy
                     cursorShape: Qt.PointingHandCursor
                     onClicked: folderDialog.open()
                 }
@@ -117,7 +119,7 @@ Popup {
             LogosStorageButton {
                 text: "Save"
                 variant: "primary"
-                enabled: jsonEditor.isValid
+                enabled: jsonEditor.isValid && !root.busy
                 onClicked: {
                     root.backend.saveUserConfig(jsonEditor.text)
                     root.close()

--- a/src/qml/StartNode.qml
+++ b/src/qml/StartNode.qml
@@ -13,6 +13,7 @@ OnBoardingLayout {
     property bool starting: true
     property bool success: false
     property bool started: false
+    readonly property bool busy: root.backend && root.backend.busy
 
     signal back
     signal next
@@ -139,7 +140,7 @@ OnBoardingLayout {
                 iconSource: "assets/arrow-left.png"
                 iconPosition: "left"
                 text: "Back"
-                enabled: !root.starting
+                enabled: !root.starting && !root.busy
                 onClicked: {
                     root.backend.stop()
                     root.back()
@@ -154,7 +155,7 @@ OnBoardingLayout {
                 iconSource: "assets/arrow-right.png"
                 iconPosition: "right"
                 text: "Continue"
-                enabled: root.success
+                enabled: root.success && !root.busy
                 onClicked: {
                     root.backend.saveCurrentConfig()
                     root.next()

--- a/src/qml/StorageView.qml
+++ b/src/qml/StorageView.qml
@@ -13,6 +13,7 @@ LogosStorageLayout {
     property var backend: MockBackend
 
     readonly property bool running: backend && backend.status === StorageBackend.Running
+    readonly property bool busy: backend && backend.busy
 
     Settings {
         id: settings
@@ -39,7 +40,10 @@ LogosStorageLayout {
         id: uploadDialog
         objectName: "uploadDialog"
         modality: Qt.NonModal
-        onAccepted: root.backend.uploadFile(selectedFile)
+        onAccepted: {
+            if (!root.busy)
+                root.backend.uploadFile(selectedFile)
+        }
         currentFolder: StandardPaths.standardLocations(
                            StandardPaths.HomeLocation)[0]
     }
@@ -90,6 +94,7 @@ LogosStorageLayout {
                         Layout.fillHeight: true
                         backend: root.backend
                         running: root.running
+                        busy: root.busy
                         onUploadRequested: uploadDialog.open()
                     }
 
@@ -98,6 +103,7 @@ LogosStorageLayout {
                         Layout.fillHeight: true
                         backend: root.backend
                         running: root.running
+                        busy: root.busy
                     }
                 }
 
@@ -135,6 +141,7 @@ LogosStorageLayout {
             Layout.minimumHeight: 0
             backend: root.backend
             running: root.running
+            busy: root.busy
             downloadFolderPath: settings.downloadFolderPath
         }
     }

--- a/src/qml/UploadWidget.qml
+++ b/src/qml/UploadWidget.qml
@@ -12,6 +12,7 @@ Card {
 
     property var backend: MockBackend
     property bool running: false
+    property bool busy: false
     property real totalBytes: 0
     property real uploadedBytes: 0
     property string uploadedCid: ""
@@ -59,7 +60,7 @@ Card {
         anchors.right: parent.right
         anchors.bottom: uploadBottomTitle.top
         visible: !root.isUploading && !root.isDone
-        opacity: root.running ? 1.0 : 0.4
+        opacity: root.running && !root.busy ? 1.0 : 0.4
 
         Behavior on opacity {
             NumberAnimation { duration: 200 }
@@ -297,8 +298,8 @@ Card {
     MouseArea {
         objectName: "uploadButton"
         anchors.fill: parent
-        cursorShape: root.running ? Qt.PointingHandCursor : Qt.ArrowCursor
-        enabled: !root.isUploading && !root.isDone && root.running
+        cursorShape: root.running && !root.busy ? Qt.PointingHandCursor : Qt.ArrowCursor
+        enabled: !root.isUploading && !root.isDone && root.running && !root.busy
         onClicked: root.uploadRequested()
     }
 }


### PR DESCRIPTION
## Problem

When `storage_ui` is hosted inside Basecamp, widget refreshes can intermittently fail with empty `LogosResult` errors, for example:

```text
Failed to refresh space:
```

The same flows work reliably in the standalone storage UI app.

The issue appears in Basecamp-hosted mode because the UI talks to `storage_module` through the hosted Qt Remote Objects/SDK path. Some generated synchronous SDK calls can spin a nested Qt event loop while waiting for remote/deferred results. If multiple synchronous module reads are queued independently, a later queued call can re-enter before the previous call has fully returned or before QtRO cleanup/completion handling has settled.

This was observed with startup widget refreshes and after file upload completion.

## Symptoms

- Initial hosted storage UI sometimes failed to populate peers/space/manifests.
- `debug()` and `space()` could return an empty failed `LogosResult`.
- Upload itself succeeded and the uploaded file appeared in the manifest list.
- Immediately after upload, `refreshSpace()` could still fail with:

```text
Failed to refresh space:
```

## Root Cause

`StorageBackend::fetchWidgetsData()` and upload/remove completion paths queued multiple synchronous SDK reads as separate sibling queued calls.

`Qt::QueuedConnection` preserves event ordering, but it does not guarantee that a synchronous SDK call will fully complete without processing other queued events. The underlying QtRO/SDK path can enter nested event loops while waiting for results, allowing subsequent queued calls to run reentrantly.

In Basecamp-hosted mode, that can cause overlapping/reentrant calls through the same remote wrapper/client path, producing empty failed `LogosResult` values even though the storage module itself is healthy.

## Fix

Replace sibling queued widget refresh calls with a chained refresh sequence.

Startup now does:

```text
debug -> space -> manifests
```

Upload/remove refresh now does:

```text
space -> manifests
```

with each step queued only after the previous one returns.

## Why This Works

This keeps the Basecamp-hosted UI from having several pending sibling synchronous SDK reads at once.

Each step is scheduled only after the previous step has returned, giving the QtRO/SDK path an event-loop turn to finish completion delivery and cleanup before the next synchronous module read begins.

This matches the defensive pattern already used in `logos-chat-ui`, where synchronous module reads are deferred out of module event callbacks to avoid QtRO reentrancy/timeouts.

## Validation

Tested manually in Basecamp-hosted `storage_ui`:

- Startup widgets load.
- Peers/space/manifests render.
- Upload succeeds.
- Uploaded file appears in manifests.
- No post-upload `refreshSpace` error.

