### PR TITLE
fix: use "destroy" when stopping the node

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41797,11 +41797,11 @@
         "logos-storage": "logos-storage"
       },
       "locked": {
-        "lastModified": 1782741442,
-        "narHash": "sha256-Qi6f9VgBVsgClIum2e1L36CHh2Zzaf5nK0V1biWv0ZI=",
+        "lastModified": 1782826719,
+        "narHash": "sha256-Xr5Ztzr1Ix5BxUh4t8VzmhgIy3HlQHYqmlHtSFVP2sQ=",
         "owner": "logos-co",
         "repo": "logos-storage-module",
-        "rev": "a6e7cdc7f6eb0f2508c1d89a3bcf4bf0c855609a",
+        "rev": "974f9c66e0ef6d49f9fd83a1dab22b8a40bf5929",
         "type": "github"
       },
       "original": {

--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -90,13 +90,21 @@ void StorageBackend::init(QString configJson) {
     qDebug() << "StorageBackend::initStorage: init";
 
     if (!result) {
+        m_contextInitialized = false;
         setStatus(Destroyed);
         reportError("Failed to init storage");
         emit initCompleted(false, "Failed to init storage");
         return;
     }
 
+    m_contextInitialized = true;
     setStatus(Stopped);
+
+    if (m_eventsSubscribed) {
+        debug("new config is: " + configJson);
+        emit initCompleted(true, QString());
+        return;
+    }
 
     if (!m_logos->storage_module.on("storageStart", [this](const QVariantList& data) {
             QJsonObject payload = QJsonDocument::fromJson(data[0].toString().toUtf8()).object();
@@ -132,9 +140,27 @@ void StorageBackend::init(QString configJson) {
                 QString message = payload["message"].toString();
                 reportError("Failed to stop Storage module:" + message);
             } else {
-                setStatus(Stopped);
-
                 debug("Storage module stopped.");
+                QTimer::singleShot(0, this, [this]() {
+                    LogosResult destroyResult = m_logos->storage_module.destroy();
+                    if (!destroyResult.success) {
+                        const QString error = destroyResult.getError();
+                        if (error.isEmpty()) {
+                            qWarning() << "StorageBackend: destroy after stop returned an empty failed result;"
+                                       << "assuming the stopped context was destroyed.";
+                            m_contextInitialized = false;
+                        } else {
+                            reportError("Error when trying to destroy stopped context: " + error);
+                        }
+                    } else {
+                        m_contextInitialized = false;
+                        qDebug() << "StorageBackend: Storage module destroyed after stop.";
+                    }
+
+                    setStatus(Stopped);
+                    emit stopCompleted();
+                });
+                return;
             }
 
             emit stopCompleted();
@@ -246,6 +272,7 @@ void StorageBackend::init(QString configJson) {
     }
 
     debug("new config is: " + configJson);
+    m_eventsSubscribed = true;
 
     emit initCompleted(true, QString());
 }
@@ -262,6 +289,16 @@ void StorageBackend::start() {
         reloadIfChanged(configJsonStr);
     } else {
         debug("Cannot open the user config file.", "warning");
+    }
+
+    if (status() == Stopped && !m_contextInitialized) {
+        if (m_config.isNull()) {
+            debug("The Storage Module is not initialised properly.");
+            emit startFailed("The Storage Module is not initialised properly.");
+            return;
+        }
+
+        init(QString::fromUtf8(m_config.toJson(QJsonDocument::Compact)));
     }
 
     if (status() != Stopped) {
@@ -316,6 +353,11 @@ void StorageBackend::stop() {
 void StorageBackend::destroy() {
     qDebug() << "StorageBackend: destroy method called";
 
+    if (!m_contextInitialized) {
+        qDebug() << "StorageBackend: Storage module context already destroyed.";
+        return;
+    }
+
     auto result = m_logos->storage_module.destroy();
 
     if (!result.success) {
@@ -323,6 +365,7 @@ void StorageBackend::destroy() {
         return;
     }
 
+    m_contextInitialized = false;
     qDebug() << "StorageBackend: Storage module destroyed.";
 }
 
@@ -562,13 +605,14 @@ void StorageBackend::reloadIfChanged(QString configJsonStr) {
         return;
     }
 
-    if (status() == Stopped) {
+    if (status() == Stopped && m_contextInitialized) {
         LogosResult result = m_logos->storage_module.destroy();
 
         if (!result.success) {
             reportError("Failed to destroy the context error=" + result.getError());
             return;
         } else {
+            m_contextInitialized = false;
             setStatus(Destroyed);
         }
     }

--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -145,18 +145,20 @@ void StorageBackend::init(QString configJson) {
                     LogosResult destroyResult = m_logos->storage_module.destroy();
                     if (!destroyResult.success) {
                         const QString error = destroyResult.getError();
-                        if (error.isEmpty()) {
-                            qWarning() << "StorageBackend: destroy after stop returned an empty failed result;"
-                                       << "assuming the stopped context was destroyed.";
-                            m_contextInitialized = false;
-                        } else {
+                        if (!error.isEmpty()) {
                             reportError("Error when trying to destroy stopped context: " + error);
+                            setStatus(Stopped);
+                            emit stopCompleted();
+                            return;
                         }
+
+                        qWarning() << "StorageBackend: destroy after stop returned an empty failed result;"
+                                   << "forcing re-init on next start.";
                     } else {
-                        m_contextInitialized = false;
                         qDebug() << "StorageBackend: Storage module destroyed after stop.";
                     }
 
+                    m_contextInitialized = false;
                     setStatus(Stopped);
                     emit stopCompleted();
                 });

--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -90,14 +90,12 @@ void StorageBackend::init(QString configJson) {
     qDebug() << "StorageBackend::initStorage: init";
 
     if (!result) {
-        m_contextInitialized = false;
         setStatus(Destroyed);
         reportError("Failed to init storage");
         emit initCompleted(false, "Failed to init storage");
         return;
     }
 
-    m_contextInitialized = true;
     setStatus(Stopped);
 
     if (m_eventsSubscribed) {
@@ -144,22 +142,12 @@ void StorageBackend::init(QString configJson) {
                 QTimer::singleShot(0, this, [this]() {
                     LogosResult destroyResult = m_logos->storage_module.destroy();
                     if (!destroyResult.success) {
-                        const QString error = destroyResult.getError();
-                        if (!error.isEmpty()) {
-                            reportError("Error when trying to destroy stopped context: " + error);
-                            setStatus(Stopped);
-                            emit stopCompleted();
-                            return;
-                        }
-
-                        qWarning() << "StorageBackend: destroy after stop returned an empty failed result;"
-                                   << "forcing re-init on next start.";
+                        reportError("Error when trying to destroy stopped context: ");
+                        setStatus(Stopped);
                     } else {
                         qDebug() << "StorageBackend: Storage module destroyed after stop.";
+                        setStatus(Destroyed);
                     }
-
-                    m_contextInitialized = false;
-                    setStatus(Stopped);
                     emit stopCompleted();
                 });
                 return;
@@ -293,10 +281,10 @@ void StorageBackend::start() {
         debug("Cannot open the user config file.", "warning");
     }
 
-    if (status() == Stopped && !m_contextInitialized) {
+    if (status() == Destroyed) {
         if (m_config.isNull()) {
-            debug("The Storage Module is not initialised properly.");
-            emit startFailed("The Storage Module is not initialised properly.");
+            debug("Failed to start node: m_config not set.");
+            emit startFailed("Failed to start node: configuration not set.");
             return;
         }
 
@@ -355,7 +343,7 @@ void StorageBackend::stop() {
 void StorageBackend::destroy() {
     qDebug() << "StorageBackend: destroy method called";
 
-    if (!m_contextInitialized) {
+    if (status() == Destroyed) {
         qDebug() << "StorageBackend: Storage module context already destroyed.";
         return;
     }
@@ -367,7 +355,7 @@ void StorageBackend::destroy() {
         return;
     }
 
-    m_contextInitialized = false;
+    setStatus(Destroyed);
     qDebug() << "StorageBackend: Storage module destroyed.";
 }
 
@@ -607,14 +595,13 @@ void StorageBackend::reloadIfChanged(QString configJsonStr) {
         return;
     }
 
-    if (status() == Stopped && m_contextInitialized) {
+    if (status() == Stopped) {
         LogosResult result = m_logos->storage_module.destroy();
 
         if (!result.success) {
             reportError("Failed to destroy the context error=" + result.getError());
             return;
         } else {
-            m_contextInitialized = false;
             setStatus(Destroyed);
         }
     }

--- a/src/StorageBackend.h
+++ b/src/StorageBackend.h
@@ -196,6 +196,9 @@ class StorageBackend : public StorageBackendSimpleSource {
     LogosAPI* m_logosAPI;
     LogosModules* m_logos;
 
+    bool m_contextInitialized = false;
+    bool m_eventsSubscribed = false;
+
     // Internal configuration object. It can be updated by
     // upnp or port forwarning methods.
     QJsonDocument m_config;

--- a/src/StorageBackend.h
+++ b/src/StorageBackend.h
@@ -196,7 +196,6 @@ class StorageBackend : public StorageBackendSimpleSource {
     LogosAPI* m_logosAPI;
     LogosModules* m_logos;
 
-    bool m_contextInitialized = false;
     bool m_eventsSubscribed = false;
 
     // Internal configuration object. It can be updated by

--- a/src/qml/NodeWidget.qml
+++ b/src/qml/NodeWidget.qml
@@ -165,7 +165,8 @@ Card {
                 variant: "secondary"
                 implicitHeight: 32
                 implicitWidth: 65
-                enabled: root.backend
+                enabled: root.backend && (root.effectiveStatus === StorageBackend.Running
+                                          || root.effectiveStatus === StorageBackend.Stopped)
                 onClicked: {
                     if (!root.backend)
                         return

--- a/src/qml/NodeWidget.qml
+++ b/src/qml/NodeWidget.qml
@@ -145,7 +145,7 @@ Card {
                         case StorageBackend.Stopping:
                             return "Stopping…"
                         case StorageBackend.Destroyed:
-                            return "Not initialised"
+                            return "Stopped"
                         default:
                             return "Unknown"
                         }
@@ -166,7 +166,7 @@ Card {
                 implicitHeight: 32
                 implicitWidth: 65
                 enabled: root.backend && (root.effectiveStatus === StorageBackend.Running
-                                          || root.effectiveStatus === StorageBackend.Stopped)
+                                          || root.effectiveStatus === StorageBackend.Destroyed)
                 onClicked: {
                     if (!root.backend)
                         return


### PR DESCRIPTION
## Summary

Fixes Storage UI stop/start lifecycle handling by destroying the storage context after the node reports it has stopped, while keeping the Start/Stop button disabled during transitional states.

## What Changed

- Disable the Start/Stop button unless the node status is `Running` or `Stopped`.
- Track whether the libstorage context is currently initialized with `m_contextInitialized`.
- Track event subscription setup with `m_eventsSubscribed` to avoid stacking duplicate `.on(...)` handlers across repeated `init()` calls.
- After a successful `storageStop` event:
  - defer cleanup to the next event-loop turn,
  - call `storage_module.destroy()`,
  - mark the context uninitialized,
  - only then set status back to `Stopped` and emit `stopCompleted()`.
- On the next Start, re-run `init()` if the UI is `Stopped` but the storage context was destroyed.
- Avoid destroying an already-destroyed context from manual destroy/config reload paths.
- If post-stop destroy returns a failed result with an empty error, treat the result as untrusted, log a warning, and force re-init on the next Start instead of showing an empty error toast.

## Rationale

The underlying libstorage lifecycle is:

```text
stop => close => destroy
```

At the Storage UI level, `storage_module.destroy()` already performs `storage_close()` followed by synchronous `storage_destroy()`, so the UI should not call all three directly. The correct flow is:

```text
stop()
wait for storageStop
destroy()
```

This ensures the node is stopped before destroying the context, while also making sure the UI does not allow a new Start/Stop action before cleanup completes.

Deferring `destroy()` from the `storageStop` handler avoids making a synchronous remote call directly inside the event callback stack.

The empty-error destroy handling is intentionally conservative: when the result is not trustworthy, the UI does not assume success for reporting purposes, but it does mark the context uninitialized so the next Start safely creates a fresh context.
