### PR TITLE
fix: use new lifecycle methods

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41799,15 +41799,16 @@
       "locked": {
         "lastModified": 1782786056,
         "narHash": "sha256-nr2oKwg7y+XqBzsg5SZ0pT4loxtcnU6hU90t1eHkmXY=",
-        "owner": "logos-co",
-        "repo": "logos-storage-module",
+        "ref": "refs/pull/64/head",
         "rev": "5f064ef3ec94eb4be39f87152166bf44186f47d2",
-        "type": "github"
+        "revCount": 250,
+        "type": "git",
+        "url": "https://github.com/logos-co/logos-storage-module"
       },
       "original": {
-        "owner": "logos-co",
-        "repo": "logos-storage-module",
-        "type": "github"
+        "ref": "refs/pull/64/head",
+        "type": "git",
+        "url": "https://github.com/logos-co/logos-storage-module"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -41797,11 +41797,11 @@
         "logos-storage": "logos-storage"
       },
       "locked": {
-        "lastModified": 1782773509,
-        "narHash": "sha256-cVn3OQow8r4t+6Ntx6F1qxA1P5WGjYGYBgGQeCxIZ3k=",
+        "lastModified": 1782786056,
+        "narHash": "sha256-nr2oKwg7y+XqBzsg5SZ0pT4loxtcnU6hU90t1eHkmXY=",
         "owner": "logos-co",
         "repo": "logos-storage-module",
-        "rev": "61ab9a6db7b1ea1af9837622066abc7703ad1cde",
+        "rev": "5f064ef3ec94eb4be39f87152166bf44186f47d2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -24818,11 +24818,11 @@
         "nixpkgs": "nixpkgs_594"
       },
       "locked": {
-        "lastModified": 1782330542,
-        "narHash": "sha256-Hs5mrUURGXz0YPQK4f6ZDORa7lj0PpjiI2RXDhoTMnQ=",
-        "ref": "refs/tags/v0.4.0-rc4",
-        "rev": "fe8a3e66258757aa1eedde2657de71793d0f4f38",
-        "revCount": 944,
+        "lastModified": 1782754713,
+        "narHash": "sha256-1weayWC04CVRZjidrm6j9UDihDNLsacxblvZtUr5NsI=",
+        "ref": "refs/pull/1476/head",
+        "rev": "5b951b04ba45a471244918cb6a103e9c5d1464bb",
+        "revCount": 947,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-storage/logos-storage-nim"
@@ -41797,11 +41797,11 @@
         "logos-storage": "logos-storage"
       },
       "locked": {
-        "lastModified": 1782741442,
-        "narHash": "sha256-Qi6f9VgBVsgClIum2e1L36CHh2Zzaf5nK0V1biWv0ZI=",
+        "lastModified": 1782773509,
+        "narHash": "sha256-cVn3OQow8r4t+6Ntx6F1qxA1P5WGjYGYBgGQeCxIZ3k=",
         "owner": "logos-co",
         "repo": "logos-storage-module",
-        "rev": "a6e7cdc7f6eb0f2508c1d89a3bcf4bf0c855609a",
+        "rev": "61ab9a6db7b1ea1af9837622066abc7703ad1cde",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -24828,7 +24828,7 @@
         "url": "https://github.com/logos-storage/logos-storage-nim"
       },
       "original": {
-        "ref": "refs/tags/v0.4.0-rc4",
+        "ref": "refs/pull/1476/head",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-storage/logos-storage-nim"
@@ -41797,11 +41797,11 @@
         "logos-storage": "logos-storage"
       },
       "locked": {
-        "lastModified": 1782786056,
-        "narHash": "sha256-nr2oKwg7y+XqBzsg5SZ0pT4loxtcnU6hU90t1eHkmXY=",
+        "lastModified": 1782816185,
+        "narHash": "sha256-YyEXxts2WzHheGfFpyUPedfeUUkfX3t9bZF3nkmtLbc=",
         "ref": "refs/pull/64/head",
-        "rev": "5f064ef3ec94eb4be39f87152166bf44186f47d2",
-        "revCount": 250,
+        "rev": "f8856f97599196120038a10a2caa09bfe52c9313",
+        "revCount": 251,
         "type": "git",
         "url": "https://github.com/logos-co/logos-storage-module"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -24818,11 +24818,11 @@
         "nixpkgs": "nixpkgs_594"
       },
       "locked": {
-        "lastModified": 1782754713,
-        "narHash": "sha256-1weayWC04CVRZjidrm6j9UDihDNLsacxblvZtUr5NsI=",
+        "lastModified": 1782783609,
+        "narHash": "sha256-i+l0vcU30P4Y/70rEc4MI8OhgGeIq2kIHjXNACtoK9E=",
         "ref": "refs/pull/1476/head",
-        "rev": "5b951b04ba45a471244918cb6a103e9c5d1464bb",
-        "revCount": 947,
+        "rev": "ebc0bed04a5e84ae7a87d8a6b8c31e6075740950",
+        "revCount": 955,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/logos-storage/logos-storage-nim"

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     logos-module-builder.url = "github:logos-co/logos-module-builder";
     nix-bundle-lgx.url = "github:logos-co/nix-bundle-lgx";
-    storage_module.url = "github:logos-co/logos-storage-module";
+    storage_module.url = "git+https://github.com/logos-co/logos-storage-module?ref=refs/pull/64/head";
   };
 
   outputs = inputs@{ logos-module-builder, ... }:

--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -560,7 +560,11 @@ void StorageBackend::saveUserConfig(QString configJsonStr) {
         return;
     }
 
-    m_config = config;
+    if (m_eventsSubscribed) {
+        m_config = config;
+    } else {
+        loadConfig(configJsonStr);
+    }
 }
 
 void StorageBackend::applyUserConfig(QString configJsonStr) {

--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -2,6 +2,7 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QDir>
+#include <QEventLoop>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonArray>
@@ -30,7 +31,8 @@ StorageBackend::StorageBackend(LogosAPI* logosAPI, QObject* parent)
     : StorageBackendSimpleSource(parent), m_logosAPI(nullptr), m_logos(nullptr) {
     qDebug() << "Initializing StorageBackend...";
 
-    setStatus(Destroyed);
+    m_config = defaultConfig();
+    setStatus(Stopped);
     setDefaultListenPort(DEFAULT_LISTEN_PORT);
     setDefaultConfigJson(QString::fromUtf8(defaultConfig().toJson(QJsonDocument::Indented)));
 
@@ -75,28 +77,21 @@ void StorageBackend::debug(const QString& log, const QString& level) {
     }
 }
 
-void StorageBackend::init(QString configJson) {
-    qDebug() << "StorageBackend::initStorage called";
+void StorageBackend::loadConfig(QString configJson) {
+    qDebug() << "StorageBackend::loadConfig called";
 
     m_config = QJsonDocument::fromJson(configJson.toUtf8());
     if (m_config.isNull()) {
         reportError("Failed to create the storage: invalid JSON config:" + configJson);
-        emit initCompleted(false, "Failed to create the storage, invalid json config");
-        return;
-    }
-
-    bool result = m_logos->storage_module.init(configJson);
-
-    qDebug() << "StorageBackend::initStorage: init";
-
-    if (!result) {
-        setStatus(Destroyed);
-        reportError("Failed to init storage");
-        emit initCompleted(false, "Failed to init storage");
         return;
     }
 
     setStatus(Stopped);
+
+    if (m_eventsSubscribed) {
+        debug("new config is: " + configJson);
+        return;
+    }
 
     if (!m_logos->storage_module.on("storageStart", [this](const QVariantList& data) {
             QJsonObject payload = QJsonDocument::fromJson(data[0].toString().toUtf8()).object();
@@ -132,9 +127,14 @@ void StorageBackend::init(QString configJson) {
                 QString message = payload["message"].toString();
                 reportError("Failed to stop Storage module:" + message);
             } else {
+                debug("Storage module stopped.");
                 setStatus(Stopped);
 
-                debug("Storage module stopped.");
+                if (m_restartAfterStop) {
+                    m_restartAfterStop = false;
+                    QMetaObject::invokeMethod(this, &StorageBackend::start,
+                                              Qt::QueuedConnection);
+                }
             }
 
             emit stopCompleted();
@@ -246,8 +246,7 @@ void StorageBackend::init(QString configJson) {
     }
 
     debug("new config is: " + configJson);
-
-    emit initCompleted(true, QString());
+    m_eventsSubscribed = true;
 }
 
 void StorageBackend::start() {
@@ -259,7 +258,13 @@ void StorageBackend::start() {
 
     if (file.exists() && file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         QString configJsonStr = QString::fromUtf8(file.readAll());
-        reloadIfChanged(configJsonStr);
+        QJsonDocument config = QJsonDocument::fromJson(configJsonStr.toUtf8());
+        if (config.isNull()) {
+            reportError("Failed to start storage: invalid JSON config:" + configJsonStr);
+            emit startFailed("Failed to start storage, invalid json config");
+            return;
+        }
+        m_config = config;
     } else {
         debug("Cannot open the user config file.", "warning");
     }
@@ -273,7 +278,7 @@ void StorageBackend::start() {
     setStatus(Starting);
     debug("Starting Storage module...");
 
-    auto result = m_logos->storage_module.start();
+    auto result = m_logos->storage_module.start(configJson());
 
     if (!result) {
         setStatus(Stopped);
@@ -311,19 +316,6 @@ void StorageBackend::stop() {
     }
 
     qDebug() << "StorageBackend: stop command sent, waiting for events.";
-}
-
-void StorageBackend::destroy() {
-    qDebug() << "StorageBackend: destroy method called";
-
-    auto result = m_logos->storage_module.destroy();
-
-    if (!result.success) {
-        reportError("Error when trying to destroy: " + result.getError());
-        return;
-    }
-
-    qDebug() << "StorageBackend: Storage module destroyed.";
 }
 
 void StorageBackend::logDebugInfo() {
@@ -542,44 +534,6 @@ void StorageBackend::refreshSpace() {
     emit spaceUpdated(total, used);
 }
 
-void StorageBackend::reloadIfChanged(QString configJsonStr) {
-    QJsonDocument config = QJsonDocument::fromJson(configJsonStr.toUtf8());
-    if (config.isNull()) {
-        debug("Invalid json detected !");
-        return;
-    }
-
-    if (m_config == config) {
-        debug("No change detected in the config");
-        return;
-    }
-
-    debug("New config detected");
-
-    if (status() == Running || status() == Stopping ||
-        status() == Starting) {
-        debug("Cannot reload the config while running, stopping or starting...");
-        return;
-    }
-
-    if (status() == Stopped) {
-        LogosResult result = m_logos->storage_module.destroy();
-
-        if (!result.success) {
-            reportError("Failed to destroy the context error=" + result.getError());
-            return;
-        } else {
-            setStatus(Destroyed);
-        }
-    }
-
-    init(configJsonStr);
-
-    m_config = config;
-    saveUserConfig(configJsonStr);
-    setStatus(Stopped);
-}
-
 void StorageBackend::saveCurrentConfig() {
     qDebug() << "StorageBackend::saveCurrentConfig";
     saveUserConfig(configJson());
@@ -587,6 +541,12 @@ void StorageBackend::saveCurrentConfig() {
 
 void StorageBackend::saveUserConfig(QString configJsonStr) {
     qDebug() << "StorageBackend::saveUserConfig";
+
+    QJsonDocument config = QJsonDocument::fromJson(configJsonStr.toUtf8());
+    if (config.isNull()) {
+        reportError("Invalid json config" + configJsonStr);
+        return;
+    }
 
     QString folderPath = QFileInfo(USER_CONFIG_PATH).absolutePath();
     QDir().mkpath(folderPath);
@@ -597,13 +557,41 @@ void StorageBackend::saveUserConfig(QString configJsonStr) {
         debug("Config saved to " + USER_CONFIG_PATH);
     } else {
         reportError("Failed to save config to " + USER_CONFIG_PATH);
+        return;
     }
+
+    m_config = config;
+}
+
+void StorageBackend::applyUserConfig(QString configJsonStr) {
+    qDebug() << "StorageBackend::applyUserConfig";
 
     QJsonDocument config = QJsonDocument::fromJson(configJsonStr.toUtf8());
     if (config.isNull()) {
         reportError("Invalid json config" + configJsonStr);
         return;
     }
+
+    if (status() == Starting || status() == Stopping) {
+        reportError("Cannot apply config while the Storage Module is starting or stopping.");
+        return;
+    }
+
+    const bool wasRunning = status() == Running;
+    const bool changed = m_config != config;
+    saveUserConfig(configJsonStr);
+
+    if (!wasRunning) {
+        setStatus(Stopped);
+        return;
+    }
+
+    if (!changed) {
+        return;
+    }
+
+    m_restartAfterStop = true;
+    stop();
 }
 
 QJsonDocument StorageBackend::defaultConfig() {
@@ -684,7 +672,7 @@ void StorageBackend::enableUpnpConfig() {
 
     obj["nat"] = "upnp";
 
-    reloadIfChanged(QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Indented)));
+    saveUserConfig(QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Indented)));
 }
 
 void StorageBackend::enableNatExtConfig(int tcpPort) {
@@ -717,7 +705,7 @@ void StorageBackend::enableNatExtConfig(int tcpPort) {
             obj["nat"] = "extip:" + ip;
         }
 
-        reloadIfChanged(QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+        saveUserConfig(QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
 
         emit natExtConfigCompleted();
     });
@@ -831,10 +819,10 @@ void StorageBackend::loadUserConfig() {
     QFile file(USER_CONFIG_PATH);
 
     if (file.exists() && file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        init(QString::fromUtf8(file.readAll()));
+        loadConfig(QString::fromUtf8(file.readAll()));
     } else {
         debug("Failed to read the user config file, fallback to default config");
-        init(QString::fromUtf8(defaultConfig().toJson(QJsonDocument::Indented)));
+        loadConfig(QString::fromUtf8(defaultConfig().toJson(QJsonDocument::Indented)));
     }
 }
 

--- a/src/StorageBackend.h
+++ b/src/StorageBackend.h
@@ -8,7 +8,6 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
-#include <QTimer>
 
 static const int RET_OK = 0;
 static const int RET_PROGRESS = 3;
@@ -48,24 +47,10 @@ class StorageBackend : public StorageBackendSimpleSource {
     ~StorageBackend();
 
   public slots:
-    // Init the Storage Module using the config json
-    // passed in parameter.
-    // It subscribes to events:
-    // 1- storageStart
-    // 2- storageStop
-    // 3- storageUploadProgress
-    // 4- storageUploadDone
-    // 5- storageDownloadProgress
-    // 6- storageDownloadProgress
-    void init(QString configJson) override;
-
     // Start the node
     // If the user configuration has changed, it will
     // reloaded it.
     void start() override;
-
-    // Destroy the Storage Module
-    void destroy() override;
 
     // Emit stopCompleted() on completion of it the module is not started
     void stop() override;
@@ -114,6 +99,9 @@ class StorageBackend : public StorageBackendSimpleSource {
     // into the user config json.
     void saveUserConfig(QString configJson) override;
 
+    // Save a new config and restart the node if it is currently running.
+    void applyUserConfig(QString configJson) override;
+
     // Save the current config object
     // into the user config json.
     void saveCurrentConfig() override;
@@ -123,19 +111,6 @@ class StorageBackend : public StorageBackendSimpleSource {
 
     // Get the content of the user config file
     QString getUserConfig() override;
-
-    // Take a new config json and reload the Storage context
-    // if the configuration has changed.
-    //
-    // This method cannot be used if the Storage Module
-    // is running, starting or stopping.
-    //
-    // If the Storage Module was already created,
-    // it will be destroyed first.
-    //
-    // On success, the status will be set to Stopped.
-    //
-    void reloadIfChanged(QString configJson) override;
 
     // Enables the upnp in the config
     // and re-create a context with the new configuration
@@ -192,9 +167,15 @@ class StorageBackend : public StorageBackendSimpleSource {
     // Emit error(message)
     void reportError(const QString& message);
 
+    // Load a config JSON into the backend and subscribe to module events once.
+    void loadConfig(QString configJson);
+
     // Logos related variables
     LogosAPI* m_logosAPI;
     LogosModules* m_logos;
+
+    bool m_eventsSubscribed = false;
+    bool m_restartAfterStop = false;
 
     // Internal configuration object. It can be updated by
     // upnp or port forwarning methods.

--- a/src/StorageBackend.rep
+++ b/src/StorageBackend.rep
@@ -7,8 +7,7 @@ class StorageBackend
         Stopped = 0,
         Starting = 1,
         Running = 2,
-        Stopping = 3,
-        Destroyed = 4
+        Stopping = 3
     }
 
     PROP(QString debugLogs READONLY)
@@ -17,10 +16,8 @@ class StorageBackend
     PROP(QString defaultConfigJson READONLY)
 
     // Lifecycle
-    SLOT(void init(QString configJson))
     SLOT(void start())
     SLOT(void stop())
-    SLOT(void destroy())
 
     // Upload / Download
     SLOT(void uploadFile(QUrl url))
@@ -36,10 +33,10 @@ class StorageBackend
 
     // Config
     SLOT(void saveUserConfig(QString configJson))
+    SLOT(void applyUserConfig(QString configJson))
     SLOT(void saveCurrentConfig())
     SLOT(void loadUserConfig())
     SLOT(QString getUserConfig())
-    SLOT(void reloadIfChanged(QString configJson))
     SLOT(QString configJson())
 
     // Network / Onboarding
@@ -57,7 +54,6 @@ class StorageBackend
     SLOT(void logPeerId())
 
     // Lifecycle signals
-    SIGNAL(initCompleted(bool success, QString error))
     SIGNAL(startCompleted())
     SIGNAL(startFailed(QString error))
     SIGNAL(stopCompleted())

--- a/src/StorageUIPlugin.cpp
+++ b/src/StorageUIPlugin.cpp
@@ -15,27 +15,18 @@ StorageUIPlugin::StorageUIPlugin(QObject* parent)
 
 StorageUIPlugin::~StorageUIPlugin()
 {
-    // Same branching as legacy destroyWidget (minus QQuickWidget):
-    // Destroyed → noop; not Running → destroy(); Running → queued stop,
-    // wait up to 2s for stopCompleted, then destroy().
     StorageBackend* backend = m_backend;
     if (!backend)
         return;
 
     const StorageStatus s = backend->status();
 
-    if (s == StorageBackendSimpleSource::Destroyed) {
-        qDebug() << "StorageUIPlugin: teardown skipped (backend destroyed)";
-        return;
-    }
-
     if (s != StorageBackendSimpleSource::Running) {
-        qDebug() << "StorageUIPlugin: backend not running, destroying context";
-        backend->destroy();
+        qDebug() << "StorageUIPlugin: backend not running, teardown skipped";
         return;
     }
 
-    qDebug() << "StorageUIPlugin: stopping backend before destroy";
+    qDebug() << "StorageUIPlugin: stopping backend during teardown";
 
     QEventLoop loop;
     QTimer timeout;
@@ -53,8 +44,6 @@ StorageUIPlugin::~StorageUIPlugin()
 
     timeout.start(2000);
     loop.exec();
-
-    backend->destroy();
 }
 
 void StorageUIPlugin::initLogos(LogosAPI* api)

--- a/src/qml/MockBackend.qml
+++ b/src/qml/MockBackend.qml
@@ -37,7 +37,6 @@ QtObject {
     function stop() {
         status = 0
     }
-    function destroy() {}
     function checkNodeIsUp() {}
     function fetchWidgetsData() {}
     function uploadFile(url) {}
@@ -56,9 +55,9 @@ QtObject {
     function logVersion() {}
     function restartOnboarding() {}
     function saveUserConfig(json) {}
+    function applyUserConfig(json) {}
     function saveCurrentConfig() {}
     function loadUserConfig() {}
-    function reloadIfChanged(json) {}
     function enableUpnpConfig() {}
     function enableNatExtConfig(tcpPort) {
         natExtConfigCompleted()

--- a/src/qml/NodeWidget.qml
+++ b/src/qml/NodeWidget.qml
@@ -14,7 +14,7 @@ Card {
     property var backend: MockBackend
     property bool nodeIsUp: false
     property bool blinkOn: false
-    readonly property int effectiveStatus: root.backend ? root.backend.status : StorageBackend.Destroyed
+    readonly property int effectiveStatus: root.backend ? root.backend.status : StorageBackend.Stopped
 
     property string downloadFolderPath: ""
 
@@ -144,8 +144,6 @@ Card {
                             return "Running"
                         case StorageBackend.Stopping:
                             return "Stopping…"
-                        case StorageBackend.Destroyed:
-                            return "Not initialised"
                         default:
                             return "Unknown"
                         }
@@ -165,7 +163,8 @@ Card {
                 variant: "secondary"
                 implicitHeight: 32
                 implicitWidth: 65
-                enabled: root.backend
+                enabled: root.backend && (root.effectiveStatus === StorageBackend.Running
+                                          || root.effectiveStatus === StorageBackend.Stopped)
                 onClicked: {
                     if (!root.backend)
                         return

--- a/src/qml/SettingsPopup.qml
+++ b/src/qml/SettingsPopup.qml
@@ -119,7 +119,7 @@ Popup {
                 variant: "primary"
                 enabled: jsonEditor.isValid
                 onClicked: {
-                    root.backend.saveUserConfig(jsonEditor.text)
+                    root.backend.applyUserConfig(jsonEditor.text)
                     root.close()
                 }
             }


### PR DESCRIPTION
> ## Related PRs
>
> This is part of the lifecycle simplification across the storage stack:
>
> - logos-storage-nim: https://github.com/logos-storage/logos-storage-nim/pull/1476
> - logos-storage-module: https://github.com/logos-co/logos-storage-module/pull/64
> - logos-storage-ui: https://github.com/logos-co/logos-storage-ui/pull/54 (this PR)

## Summary

Updates `logos-storage-ui` to consume the simplified `logos-storage-module` lifecycle API.

The UI now treats the storage module lifecycle as:

- `start(config)`
- `stop()`

and removes stale assumptions around separate module-side `init` / `destroy` lifecycle methods.

## Motivation

The storage stack lifecycle was simplified so clients no longer coordinate low-level context setup and teardown. `logos-storage-module` now owns the libstorage context internally and exposes a service-level API: start from config, then stop.

The UI should match that model instead of carrying old lifecycle vocabulary or compatibility paths. This avoids building UI behavior around module methods that no longer exist and keeps the UI aligned with the new generated SDK surface.

## Changes

- Updates backend startup to call `storage_module.start(configJson())`.
- Keeps UI-facing `backend.start()` as the QML entry point; the backend loads the saved config and forwards it to the module.
- Keeps shutdown as `storage_module.stop()`.
- Removes stale public backend lifecycle surface for `init` and `destroy`.
- Removes the obsolete `Destroyed` backend state.
- Starts the backend in `Stopped` state with a default config loaded.
- Replaces the old public init slot with a private config-loading helper.
- Updates plugin teardown so it only stops the backend when it is running.
- Updates QML/mock enum and lifecycle usage to match the simplified state model.

## Lifecycle Contract

From QML/UI code:

```text
backend.start()
  loads the current config and calls storage_module.start(config)

backend.stop()
  calls storage_module.stop()
```

The UI no longer exposes or depends on separate `init` / `destroy` steps. Config changes are applied by saving the config and restarting only when the node is already running.

## Notes

`downloadManifest()` behavior is intentionally not changed in this PR. This PR is focused on lifecycle alignment with the updated storage module API.