### PR TITLE
chore: remove extra check

### DIFF
--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -654,9 +654,6 @@ QJsonDocument StorageBackend::defaultConfig() {
 }
 
 bool StorageBackend::isLegacyBootstrap(const QJsonArray& bootstrap) {
-    if (bootstrap.size() != LEGACY_BOOTSTRAP_NODES.size()) {
-        return false;
-    }
     for (const QJsonValue& node : bootstrap) {
         if (!LEGACY_BOOTSTRAP_NODES.contains(node.toString())) {
             return false;

--- a/src/qml/JsonEditor.qml
+++ b/src/qml/JsonEditor.qml
@@ -33,7 +33,7 @@ Rectangle {
 
     function validate() {
         try {
-            const cfg = JSON.parse(jsonArea.text)
+            JSON.parse(jsonArea.text)
             isValid = true
         } catch (e) {
             isValid = false

--- a/src/qml/JsonEditor.qml
+++ b/src/qml/JsonEditor.qml
@@ -34,11 +34,7 @@ Rectangle {
     function validate() {
         try {
             const cfg = JSON.parse(jsonArea.text)
-            const bootstrap = cfg["bootstrap-node"]
-            // "bootstrap-node" overrides "network", so setting both conflicts.
-            const conflict = !!cfg["network"] && Array.isArray(bootstrap)
-                    && bootstrap.length > 0
-            isValid = !conflict
+            isValid = true
         } catch (e) {
             isValid = false
         }


### PR DESCRIPTION
This PR removes 2 validation checks: 

1. The old legacy nodes size: The legacy nodes should be detected even if there is 1 or 2 bootstrap nodes 
2. Remove confusing check between bootstrap nodes and network