### PR TITLE
fix: reporting number of peers in UI

### DIFF
--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -765,6 +765,7 @@ void StorageBackend::checkNodeIsUp() {
 
     QVariantMap table = result.getValue<QVariantMap>("table");
     QVariantList nodes = table["nodes"].toList();
+    emit peersUpdated(nodes.size());
 
     debug(QString("Connected peers: %1").arg(nodes.size()));
 

--- a/src/StorageBackend.cpp
+++ b/src/StorageBackend.cpp
@@ -57,6 +57,16 @@ void StorageBackend::reportError(const QString& message) {
     emit error(message);
 }
 
+static int seenPeerCount(const QVariantList& nodes) {
+    int count = 0;
+    for (const QVariant& node : nodes) {
+        if (node.toMap().value("seen").toBool()) {
+            ++count;
+        }
+    }
+    return count;
+}
+
 void StorageBackend::debug(const QString& log, const QString& level) {
     QString current = debugLogs();
     if (!current.isEmpty()) {
@@ -371,7 +381,7 @@ void StorageBackend::logDebugInfo() {
     debug(QString::fromUtf8(QJsonDocument::fromVariant(map).toJson(QJsonDocument::Indented)));
 
     QVariantList nodes = map.value("table").toMap().value("nodes").toList();
-    emit peersUpdated(nodes.size());
+    emit peersUpdated(seenPeerCount(nodes));
 }
 
 void StorageBackend::uploadFile(QUrl url) {
@@ -765,11 +775,12 @@ void StorageBackend::checkNodeIsUp() {
 
     QVariantMap table = result.getValue<QVariantMap>("table");
     QVariantList nodes = table["nodes"].toList();
-    emit peersUpdated(nodes.size());
+    const int peers = seenPeerCount(nodes);
+    emit peersUpdated(peers);
 
-    debug(QString("Connected peers: %1").arg(nodes.size()));
+    debug(QString("Connected peers: %1").arg(peers));
 
-    if (nodes.isEmpty()) {
+    if (peers == 0) {
         qWarning() << "StorageBackend::checkNodeIsUp No peers connected";
         emit nodeIsntUp("No peers connected. "
                         "Try modifying the discovery port (default 8090) in the advanced settings.");

--- a/src/qml/HealthIndicator.qml
+++ b/src/qml/HealthIndicator.qml
@@ -7,7 +7,7 @@ QtObject {
     property var backend: MockBackend
     property bool nodeIsUp: false
     property bool blinkOn: true
-    readonly property int threeMinutes: 180000
+    readonly property int checkIntervalMs: 60000
 
     // 600 ms blink toggle
     property Timer blinkTimer: Timer {
@@ -17,9 +17,9 @@ QtObject {
         onTriggered: root.blinkOn = !root.blinkOn
     }
 
-    // Reachability check every 3 minutes while running
+    // Reachability check while running
     property Timer checkTimer: Timer {
-        interval: root.threeMinutes
+        interval: root.checkIntervalMs
         repeat: true
         running: root.backend !== null && root.backend.status === StorageBackend.Running
         triggeredOnStart: true

--- a/src/qml/PeersWidget.qml
+++ b/src/qml/PeersWidget.qml
@@ -74,7 +74,8 @@ Card {
             }
 
             LogosText {
-                text: "Peer connections are in good standing."
+                text: root.peers > 0 ? "Peer connections are in good standing."
+                                     : "No active peer connections."
                 font.pixelSize: Theme.typography.secondaryText
                 color: Theme.palette.textMuted
                 font.family: "monospace"


### PR DESCRIPTION
## Summary

- Count only active/seen peers in the peer widget instead of all routing-table nodes.
- Refresh peer count during periodic node health checks.
- Reduce health check interval to 60 seconds.
- Show a clearer zero-peer message: “No active peer connections.”

After the fix, at the beginning, the number of peers in good standing will naturally be `0`. Thus, the user will see:

<img width="996" height="1006" alt="image" src="https://github.com/user-attachments/assets/2000655c-5db3-481c-a0de-fd58f619216e" />

Notice the consistent red colors in the relevant controls.

The status is controlled every `60s` (change from `180s`). When at least one peer is connected, the  UI will reflect that:

<img width="880" height="990" alt="image" src="https://github.com/user-attachments/assets/5f3504a2-01cd-46d5-a928-5192132e6dfa" />
