### PR TITLE
fix: remove duplicate node status label

### DIFF
--- a/src/qml/NodeWidget.qml
+++ b/src/qml/NodeWidget.qml
@@ -154,28 +154,6 @@ Card {
                     font.pixelSize: Theme.typography.primaryText
                     color: Theme.palette.textSecondary
                     Layout.alignment: Qt.AlignVCenter
-
-                    LogosText {
-                        text: {
-                            switch (root.effectiveStatus) {
-                            case StorageBackend.Stopped:
-                                return "Stopped"
-                            case StorageBackend.Starting:
-                                return "Starting…"
-                            case StorageBackend.Running:
-                                return "Running"
-                            case StorageBackend.Stopping:
-                                return "Stopping…"
-                            case StorageBackend.Destroyed:
-                                return "Not initialised"
-                            default:
-                                return "Unknown"
-                            }
-                        }
-                        font.pixelSize: Theme.typography.primaryText
-                        color: Theme.palette.textSecondary
-                    }
-
                 }
             }
 


### PR DESCRIPTION
## Summary

- Fix overlapping node status text when the node is stopped.
- Remove the accidentally nested status label introduced during merge conflict resolution in the mix-toggle PR.
- Keep the node card rendering a single status value.

**BEFORE**:

<img width="880" height="356" alt="image" src="https://github.com/user-attachments/assets/d0a03cdd-7db1-466a-92ae-a9dcaca3cfa0" />

**AFTER**:

<img width="914" height="402" alt="image" src="https://github.com/user-attachments/assets/5d95761d-3708-40c5-9d7c-cc4b4fedf45b" />
